### PR TITLE
make changes for output and debug log issues

### DIFF
--- a/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
+++ b/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
@@ -344,11 +344,10 @@ override 'getHostStatsSummary' => sub {
 };
 
 override 'startStatsCollection' => sub {
-	my ( $self ) = @_;
+	my ( $self, $tmpDir ) = @_;
 	# start kubectl top
 	my $servicesRef = $self->getAllServicesByType('appServer');
 	my $service = $servicesRef->[0];
-	my $tmpDir           = $self->getParamValue('tmpDir');
 	my $destinationDir = "$tmpDir/statistics/kubernetes";
 	`mkdir -p $destinationDir`;
 	$service->host->kubernetesTopPodAllNamespaces(15, $destinationDir);

--- a/runHarness/DataManagers/DataManager.pm
+++ b/runHarness/DataManagers/DataManager.pm
@@ -96,12 +96,6 @@ override 'initialize' => sub {
 	}
 	$self->setParamValue('dbLoaderDir', $dbLoaderDir);
 
-	my $tmpDir    =  $self->getParamValue('tmpDir' ); 
-	if ( !( $tmpDir =~ /^\// ) ) {
-		$tmpDir = $weathervaneHome . "/" . $tmpDir;
-	}
-	$self->setParamValue('tmpDir', $tmpDir);
-
 	super();
 
 };

--- a/runHarness/RunProcedures/FullRunProcedure.pm
+++ b/runHarness/RunProcedures/FullRunProcedure.pm
@@ -21,7 +21,7 @@ use Parameters qw(getParamValue);
 use POSIX;
 use JSON;
 use Log::Log4perl qw(get_logger);
-use Utils qw(callMethodOnObjectsParamListParallel1 callMethodOnObjectsParallel callBooleanMethodOnObjectsParallel callMethodsOnObjectParallel);
+use Utils qw(callMethodOnObjectsParamListParallel1 callMethodOnObjectsParallel callBooleanMethodOnObjectsParallel callBooleanMethodOnObjectsParallel1 callMethodsOnObjectParallel);
 
 use strict;
 
@@ -46,20 +46,19 @@ override 'run' => sub {
 
 	super();
 
-	my $outputDir = $self->getParamValue('outputDir');
-	my $tmpDir    = $self->getParamValue('tmpDir');
+	my $tmpDir = $self->tmpDir;
 	my $seqnum = $self->seqnum;
 
 	# Make sure that the services know their external port numbers
 	$self->setExternalPortNumbers();
 
 	# configure the workload driver
-	my $ok = callBooleanMethodOnObjectsParallel( 'configureWorkloadDriver',
-		$self->workloadsRef );
+	my $ok = callBooleanMethodOnObjectsParallel1( 'configureWorkloadDriver',
+		$self->workloadsRef, $tmpDir );
 	if ( !$ok ) {
 		$self->cleanupAfterFailure(
 			"Couldn't configure the workload driver properly.  Exiting.",
-			$seqnum, $tmpDir, $outputDir );
+			$seqnum, $tmpDir );
 		my $runResult = RunResult->new(
 			'runNum'     => $seqnum,
 			'isPassable' => 0,
@@ -75,7 +74,7 @@ override 'run' => sub {
 	if ( !$ok ) {
 		$self->cleanupAfterFailure(
 			"Workload driver did not initialze properly.  Exiting.",
-			$seqnum, $tmpDir, $outputDir );
+			$seqnum, $tmpDir );
 		my $runResult = RunResult->new(
 			'runNum'     => $seqnum,
 			'isPassable' => 0,
@@ -95,7 +94,7 @@ override 'run' => sub {
 	if ( !$ok ) {
 		$self->cleanupAfterFailure(
 			"Workload driver did not start properly.  Exiting.",
-			$seqnum, $tmpDir, $outputDir );
+			$seqnum, $tmpDir );
 		my $runResult = RunResult->new(
 			'runNum'     => $seqnum,
 			'isPassable' => 0,
@@ -118,13 +117,13 @@ override 'run' => sub {
 	);
 
 	## get the config files
-	$self->getConfigFiles();
+	$self->getConfigFiles($tmpDir);
 
 	## get the stats files
-	$self->getStatsFiles();
+	$self->getStatsFiles($tmpDir);
 
 	## get the logs
-	$self->getLogFiles();
+	$self->getLogFiles($tmpDir);
 
 	my $sanityPassed = 1;
 
@@ -166,11 +165,7 @@ override 'run' => sub {
 
 	## for each service and the workload driver, parse stats
 	# and gather up the headers and values for the results csv
-	my $csvHashRef = $self->getStatsSummary($seqnum);
-
-	my $resultsDir = "$outputDir/$seqnum";
-	`mkdir -p $resultsDir`;
-	`mv $tmpDir/* $resultsDir/.`;
+	my $csvHashRef = $self->getStatsSummary($seqnum, $tmpDir);
 
 	# Todo: Add parsing of logs for errors
 	# my $isRunError = $self->parseLogs()
@@ -186,7 +181,6 @@ override 'run' => sub {
 		'isPassable'            => 1,
 		'isPassed'              => $isPassed,
 		'runNum'                => $seqnum,
-		'resultsDir'            => $resultsDir,
 		'resultsSummaryHashRef' => $csvHashRef,
 
 		#		'metricsHashRef'        => $self->workloadDriver->getResultMetrics(),

--- a/runHarness/RunProcedures/RunOnlyRunProcedure.pm
+++ b/runHarness/RunProcedures/RunOnlyRunProcedure.pm
@@ -20,7 +20,7 @@ use Parameters qw(getParamValue);
 use POSIX;
 use JSON;
 use Log::Log4perl qw(get_logger);
-use Utils qw(callMethodOnObjectsParamListParallel1 callMethodOnObjectsParallel callBooleanMethodOnObjectsParallel callMethodsOnObjectParallel);
+use Utils qw(callMethodOnObjectsParamListParallel1 callMethodOnObjectsParallel callBooleanMethodOnObjectsParallel callBooleanMethodOnObjectsParallel1 callMethodsOnObjectParallel);
 
 use strict;
 
@@ -43,7 +43,6 @@ override 'run' => sub {
 	my $console_logger = get_logger("Console");
 	my $debug_logger = get_logger("Weathervane::RunProcedures::RunOnlyRunProcedure");
 
-	my $outputDir = $self->getParamValue('outputDir');
 	my $tmpDir    = $self->getParamValue('tmpDir');
 
 	# Add appender to the console log to put a copy in the tmpLog directory
@@ -57,7 +56,8 @@ override 'run' => sub {
 	$appender->layout($layout);
 	$console_logger->add_appender($appender);
 
-	my $sequenceNumberFile = $self->getParamValue('sequenceNumberFile');
+	# Get the minor sequence number of the next run
+	my $sequenceNumberFile = "$tmpDir/minorsequence.num";
 	my $seqnum;
 	if ( -e "$sequenceNumberFile" ) {
 		open SEQFILE, "<$sequenceNumberFile";
@@ -66,11 +66,6 @@ override 'run' => sub {
 		$seqnum--;
 	}
 	else {
-		if ( -e "$outputDir/0" ) {
-			print
-"Sequence number file is missing, but run 0 already exists in $outputDir\n";
-			exit -1;
-		}
 		$seqnum = 0;
 		open SEQFILE, ">$sequenceNumberFile";
 		my $nextSeqNum = 1;
@@ -78,6 +73,12 @@ override 'run' => sub {
 		close SEQFILE;
 	}
 	$self->seqnum($seqnum);
+
+	# Now send all output to new subdir 	
+	$tmpDir = "$tmpDir/$seqnum";
+	if ( !( -e $tmpDir ) ) {
+		`mkdir $tmpDir`;
+	}
 
 	# Make sure that no previous Benchmark processes are still running
 	$debug_logger->debug("killOldWorkloadDrivers");
@@ -87,12 +88,12 @@ override 'run' => sub {
 	$self->setExternalPortNumbers();
 
 	# configure the workload driver
-	my $ok = callBooleanMethodOnObjectsParallel( 'configureWorkloadDriver',
-		$self->workloadsRef );
+	my $ok = callBooleanMethodOnObjectsParallel1( 'configureWorkloadDriver',
+		$self->workloadsRef, $tmpDir );
 	if ( !$ok ) {
 		$self->cleanupAfterFailure(
 			"Couldn't configure the workload driver properly.  Exiting.",
-			$seqnum, $tmpDir, $outputDir );
+			$seqnum, $tmpDir );
 		my $runResult = RunResult->new(
 			'runNum'     => $seqnum,
 			'isPassable' => 0,
@@ -102,7 +103,7 @@ override 'run' => sub {
 	}
 	
 	# Check that the users are the same as the number from the prepareOnly phase
-	if (!$self->checkUsersTxt()) {
+	if (!$self->checkUsersTxt($tmpDir)) {
 		exit;	
 	}
 	
@@ -113,7 +114,7 @@ override 'run' => sub {
 	if ( !$ok ) {
 		$self->cleanupAfterFailure(
 			"Workload driver did not initialze properly.  Exiting.",
-			$seqnum, $tmpDir, $outputDir );
+			$seqnum, $tmpDir );
 		my $runResult = RunResult->new(
 			'runNum'     => $seqnum,
 			'isPassable' => 0,
@@ -127,7 +128,7 @@ override 'run' => sub {
 	if ( !$ok ) {
 		$self->cleanupAfterFailure(
 			"Workload driver did not start properly.  Exiting.",
-			$seqnum, $tmpDir, $outputDir );
+			$seqnum, $tmpDir );
 		my $runResult = RunResult->new(
 			'runNum'     => $seqnum,
 			'isPassable' => 0,
@@ -150,13 +151,13 @@ override 'run' => sub {
 	);
 
 	## get the config files
-	$self->getConfigFiles();
+	$self->getConfigFiles($tmpDir);
 
 	## get the stats logs
-	$self->getStatsFiles();
+	$self->getStatsFiles($tmpDir);
 
 	## get the logs
-	$self->getLogFiles();
+	$self->getLogFiles($tmpDir);
 
 	my $sanityPassed = 1;
 	if ( $self->getParamValue('stopServices') ) {
@@ -197,11 +198,7 @@ override 'run' => sub {
 
 	## for each service and the workload driver, parse stats
 	# and gather up the headers and values for the results csv
-	my $csvHashRef = $self->getStatsSummary($seqnum);
-
-	my $resultsDir = "$outputDir/$seqnum";
-	`mkdir -p $resultsDir`;
-	`mv $tmpDir/* $resultsDir/.`;
+	my $csvHashRef = $self->getStatsSummary($seqnum, $tmpDir);
 
 	# Todo: Add parsing of logs for errors
 	# my $isRunError = $self->parseLogs()
@@ -217,7 +214,6 @@ override 'run' => sub {
 		'isPassable'            => 1,
 		'isPassed'              => $isPassed,
 		'runNum'                => $seqnum,
-		'resultsDir'            => $resultsDir,
 		'resultsSummaryHashRef' => $csvHashRef,
 
 		#		'metricsHashRef'        => $self->workloadDriver->getResultMetrics(),

--- a/runHarness/RunProcedures/StopRunProcedure.pm
+++ b/runHarness/RunProcedures/StopRunProcedure.pm
@@ -64,9 +64,6 @@ override 'run' => sub {
 	# clean up old logs and stats
 	$self->cleanup($tmpDir);
 	
-	# clean out the tmp directory
-	`rm -r $tmpDir/* 2>&1`;
-
 	my $runResult = RunResult->new(
 		'runNum'     => '-1',
 		'isPassable' => 0,

--- a/runHarness/RunResults/RunResult.pm
+++ b/runHarness/RunResults/RunResult.pm
@@ -25,11 +25,6 @@ has 'runNum' => (
 	isa => 'Int',
 );
 
-has 'resultsDir' => (
-	is  => 'rw',
-	isa => 'Str',
-);
-
 has 'isRunError' => (
 	is  => 'rw',
 	isa => 'Bool',

--- a/runHarness/Services/Service.pm
+++ b/runHarness/Services/Service.pm
@@ -119,14 +119,6 @@ override 'initialize' => sub {
 	}
 	$self->setParamValue('distDir', $distDir);
 	
-	# if the tmpDir doesn't start with a / then it
-	# is relative to weathervaneHome
-	my $tmpDir = $self->getParamValue('tmpDir' );
-	if ( !( $tmpDir =~ /^\// ) ) {
-		$tmpDir = $weathervaneHome . "/" . $tmpDir;
-	}
-	$self->setParamValue('tmpDir', $tmpDir);
-
 	# if the dbScriptDir doesn't start with a / then it
 	# is relative to weathervaneHome
 	my $dbScriptDir    = $self->getParamValue('dbScriptDir' );

--- a/runHarness/Workload/Workload.pm
+++ b/runHarness/Workload/Workload.pm
@@ -121,7 +121,7 @@ sub initializeRun {
 	if ( $self->useSuffix ) {
 		$suffix = $self->suffix;
 	}
-	return $self->primaryDriver->initializeRun( $seqnum, $tmpDir, $suffix );
+	return $self->primaryDriver->initializeRun( $seqnum, $tmpDir, $suffix, $tmpDir );
 }
 
 sub startRun {
@@ -132,7 +132,7 @@ sub startRun {
 	if ( $self->useSuffix ) {
 		$suffix = $self->suffix;
 	}
-	return $self->primaryDriver->startRun( $seqnum, $tmpDir, $suffix );
+	return $self->primaryDriver->startRun( $seqnum, $tmpDir, $suffix, $tmpDir );
 }
 
 sub stopRun {
@@ -338,7 +338,7 @@ sub clearDataServicesAfterStart {
 }
 
 sub configureWorkloadDriver {
-	my ($self) = @_;
+	my ($self, $tmpDir) = @_;
 	my $workloadDriver = $self->primaryDriver;
 
 	my $suffix = "";
@@ -346,7 +346,7 @@ sub configureWorkloadDriver {
 		$suffix = $self->suffix;
 	}
 
-	$workloadDriver->configure( $self->appInstancesRef, $suffix );
+	$workloadDriver->configure( $self->appInstancesRef, $suffix, $tmpDir );
 }
 
 sub cleanStatsFiles {
@@ -428,7 +428,7 @@ sub cleanLogFiles {
 }
 
 sub startStatsCollection {
-	my ($self)            = @_;
+	my ($self, $tmpDir)            = @_;
 	my $console_logger    = get_logger("Console");
 	my $workloadDriver    = $self->primaryDriver;
 	my $intervalLengthSec = $self->getParamValue('statsInterval');
@@ -440,7 +440,7 @@ sub startStatsCollection {
 	$workloadDriver->startAppStatsCollection( $intervalLengthSec, $numIntervals );
 
 	if ( $logLevel >= 3 ) {
-		callMethodOnObjectsParallel( 'startStatsCollection', $self->appInstancesRef );
+		callMethodOnObjectsParallel1( 'startStatsCollection', $self->appInstancesRef, $tmpDir );
 
 		# Start starts collection on workload driver
 		$workloadDriver->startStatsCollection( $intervalLengthSec, $numIntervals );
@@ -721,10 +721,10 @@ sub getAppInstanceStatsSummary {
 }
 
 sub getWorkloadAppStatsSummary {
-	my ($self) = @_;
+	my ($self, $tmpDir) = @_;
 	tie( my %csv, 'Tie::IxHash' );
 
-	return $self->primaryDriver->getWorkloadAppStatsSummary();
+	return $self->primaryDriver->getWorkloadAppStatsSummary($tmpDir);
 
 }
 
@@ -751,7 +751,7 @@ sub getHostStatsSummary {
 }
 
 sub getStatsSummary {
-	my ( $self, $statsLogPath, $usePrefix ) = @_;
+	my ( $self, $statsLogPath, $usePrefix, $tmpDir ) = @_;
 
 	tie( my %csv, 'Tie::IxHash' );
 	my $newBaseDestinationPath = $statsLogPath;
@@ -760,7 +760,7 @@ sub getStatsSummary {
 	}
 
 	# First get the stats for the workload driver
-	$self->primaryDriver->getStatsSummary( \%csv, $newBaseDestinationPath . "/workloadDriver" );
+	$self->primaryDriver->getStatsSummary( \%csv, $newBaseDestinationPath . "/workloadDriver", $tmpDir );
 
 	# Get the host stats by service type for each app instance
 	my $appInstancesRef = $self->appInstancesRef;

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -303,7 +303,6 @@ sub createRunConfigHash {
 	my $console_logger = get_logger("Console");
 	my $workloadNum    = $self->getParamValue('workloadNum');
 
-	my $tmpDir           = $self->getParamValue('tmpDir');
 	my $rampUp           = $self->getParamValue('rampUp');
 	my $steadyState      = $self->getParamValue('steadyState');
 	my $rampDown         = $self->getParamValue('rampDown');
@@ -487,7 +486,7 @@ sub createRunConfigHash {
 }
 
 override 'configure' => sub {
-	my ( $self, $appInstancesRef, $suffix ) = @_;
+	my ( $self, $appInstancesRef, $suffix, $tmpDir ) = @_;
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $console_logger = get_logger("Console");
@@ -503,7 +502,6 @@ override 'configure' => sub {
 	my $totalTime           = $rampUp + $steadyState + $rampDown;
 	my $usersScaleFactor    = $self->getParamValue('usersScaleFactor');
 	my $rampupInterval      = $self->getParamValue('rampupInterval');
-	my $tmpDir              = $self->getParamValue('tmpDir');
 
 	$self->portMap->{'http'} = $self->internalPortMap->{'http'};
 	
@@ -708,7 +706,7 @@ sub stopAuctionWorkloadDriverContainer {
 }
 
 sub initializeRun {
-	my ( $self, $runNum, $logDir, $suffix ) = @_;
+	my ( $self, $runNum, $logDir, $suffix, $tmpDir ) = @_;
 	my $console_logger = get_logger("Console");
 	my $logger         = get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	$self->suffix($suffix);
@@ -800,7 +798,6 @@ sub initializeRun {
 	  $self->createRunConfigHash( $self->workload->appInstancesRef, $suffix );
 
 	# Save the configuration in file form
-	my $tmpDir              = $self->getParamValue('tmpDir');
 	open( my $configFile, ">$tmpDir/run$suffix.json" )
 	  || die "Can't open $tmpDir/run$suffix.json for writing: $!";
 	print $configFile $json->encode($runRef) . "\n";
@@ -906,7 +903,7 @@ sub initializeRun {
 }
 
 sub startRun {
-	my ( $self, $runNum, $logDir, $suffix ) = @_;
+	my ( $self, $runNum, $logDir, $suffix, $tmpDir ) = @_;
 	my $console_logger = get_logger("Console");
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
@@ -1073,7 +1070,7 @@ sub startRun {
 					$startedSteadyState = 1;
 				
 					# Start collecting statistics on all hosts and services
-					$self->workload->startStatsCollection();
+					$self->workload->startStatsCollection($tmpDir);
 				} elsif (!$startedRampDown && ($curTime > ($rampUp + $steadyState))) { 
 
 					$console_logger->info("Steady-State Complete");
@@ -1527,9 +1524,9 @@ sub getResultMetrics {
 }
 
 sub getWorkloadStatsSummary {
-	my ( $self, $csvRef, $logDir ) = @_;
+	my ( $self, $csvRef, $tmpDir ) = @_;
 
-	if (!$self->parseStats()) {
+	if (!$self->parseStats($tmpDir)) {
 		return;	
 	}
 
@@ -1543,7 +1540,7 @@ sub getWorkloadStatsSummary {
 		my $appInstanceNum = $appInstanceRef->getParamValue('appInstanceNum');
 		my $prefix = "-AI${appInstanceNum}";
 
-		my $isPassed = $self->isPassed( $appInstanceRef, $logDir );
+		my $isPassed = $self->isPassed( $appInstanceRef, $tmpDir );
 		if ($isPassed) {
 			$csvRef->{"pass$prefix"} = "Y";
 		}
@@ -1587,12 +1584,12 @@ sub getHostStatsSummary {
 }
 
 sub getWorkloadAppStatsSummary {
-	my ( $self, $statsLogPath ) = @_;
+	my ( $self, $tmpDir ) = @_;
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	tie( my %csv, 'Tie::IxHash' );
 
-	if (!$self->parseStats()) {
+	if (!$self->parseStats($tmpDir)) {
 		return \%csv;	
 	}
 
@@ -1685,9 +1682,9 @@ sub getWorkloadAppStatsSummary {
 }
 
 sub getStatsSummary {
-	my ( $self, $csvRef, $statsLogPath ) = @_;
+	my ( $self, $csvRef, $statsLogPath, $tmpDir ) = @_;
 
-	if (!$self->parseStats()) {
+	if (!$self->parseStats($tmpDir)) {
 		return;	
 	}
 
@@ -1922,11 +1919,11 @@ sub setNumActiveUsers {
 }
 
 sub isPassed {
-	my ( $self, $appInstanceRef, $logDir ) = @_;
+	my ( $self, $appInstanceRef, $tmpDir ) = @_;
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 
-	if (!$self->parseStats()) {
+	if (!$self->parseStats($tmpDir)) {
 		return;	
 	}
 
@@ -1950,7 +1947,7 @@ sub isPassed {
 }
 
 sub parseStats {
-	my ( $self ) = @_;
+	my ( $self, $tmpDir ) = @_;
 	my $console_logger = get_logger("Console");
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
@@ -1958,7 +1955,6 @@ sub parseStats {
 	my $runName                 = "runW${workloadNum}";
 	my $port = $self->portMap->{'http'};
 	my $hostname = $self->host->hostName;
-	my $tmpDir = $self->getParamValue( 'tmpDir' );
 
 	if ($self->resultsValid) {
 		return 1;

--- a/runHarness/WorkloadDrivers/WorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/WorkloadDriver.pm
@@ -87,14 +87,6 @@ override 'initialize' => sub {
 	}
 	$self->setParamValue( 'distDir', $distDir );
 	
-	# if the tmpDir doesn't start with a / then it
-	# is relative to weathervaneHome
-	my $tmpDir = $self->getParamValue('tmpDir');
-	if ( !( $tmpDir =~ /^\// ) ) {
-		$tmpDir = $weathervaneHome . "/" . $tmpDir;
-	}
-	$self->setParamValue( 'tmpDir', $tmpDir );
-	
 	super();
 
 };

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -233,17 +233,91 @@ while (<FIXEDCONFIGFILE>) {
 close FIXEDCONFIGFILE;
 my $fixedConfigs = $json->decode($paramJson);
 
+my $weathervaneHome = getParamValue( $paramsHashRef, 'weathervaneHome' );
+
+# if the tmpDir doesn't start with a / then it
+# is relative to weathervaneHome
+my $tmpDir = getParamValue( $paramsHashRef, 'tmpDir');
+if ( !( $tmpDir =~ /^\// ) ) {
+	$tmpDir = $weathervaneHome . "/" . $tmpDir;
+}
+setParamValue( $paramsHashRef, 'tmpDir', $tmpDir );
+
+# if the outputDir doesn't start with a / then it
+# is relative to weathervaneHome
+my $outputDir = getParamValue( $paramsHashRef, 'outputDir' );
+if ( !( $outputDir =~ /^\// ) ) {
+	$outputDir = $weathervaneHome . "/" . $outputDir;
+}
+setParamValue( $paramsHashRef, 'outputDir', $outputDir );
+
+# if the distDir doesn't start with a / then it
+# is relative to weathervaneHome
+my $distDir         = getParamValue( $paramsHashRef, 'distDir' );
+if ( !( $distDir =~ /^\// ) ) {
+	$distDir = $weathervaneHome . "/" . $distDir;
+}
+setParamValue( $paramsHashRef, 'distDir', $distDir );
+
+# if the sequenceNumberFile doesn't start with a / then it
+# is relative to weathervaneHome
+my $sequenceNumberFile = getParamValue( $paramsHashRef, 'sequenceNumberFile' );
+if ( !( $sequenceNumberFile =~ /^\// ) ) {
+	$sequenceNumberFile = $weathervaneHome . "/" . $sequenceNumberFile;
+}
+setParamValue( $paramsHashRef, 'sequenceNumberFile', $sequenceNumberFile );
+
+# make sure the directories exist
+if ( !( -e $tmpDir ) ) {
+	`mkdir $tmpDir`;
+}
+
+if ( !( -e $outputDir ) ) {
+	`mkdir -p $outputDir`;
+}
+
+# Get the sequence number of the next run
+my $seqnum;
+if ( -e "$sequenceNumberFile" ) {
+	open SEQFILE, "<$sequenceNumberFile";
+	$seqnum = <SEQFILE>;
+	close SEQFILE;
+	if ( -e "$outputDir/$seqnum" ) {
+		print "Next run number is $seqnum, but directory for run $seqnum already exists in $outputDir\n";
+		exit -1;
+	}
+	open SEQFILE, ">$sequenceNumberFile";
+	my $nextSeqNum = $seqnum + 1;
+	print SEQFILE $nextSeqNum;
+	close SEQFILE;
+}
+else {
+	if ( -e "$outputDir/0" ) {
+		print "Sequence number file is missing, but run 0 already exists in $outputDir\n";
+		exit -1;
+	}
+	$seqnum = 0;
+	open SEQFILE, ">$sequenceNumberFile";
+	my $nextSeqNum = 1;
+	print SEQFILE $nextSeqNum;
+	close SEQFILE;
+}
+
+#clean out the tmp directory
+`rm -r $tmpDir/* 2>&1`;
+
+# Copy the version file into the output directory
+`cp $weathervaneHome/version.txt $tmpDir/version.txt`;
 
 # Set up the loggers
-my $weathervaneHome = getParamValue( $paramsHashRef, 'weathervaneHome' );
 my $console_logger = get_logger("Console");
 $console_logger->level($INFO);
 my $layout   = Log::Log4perl::Layout::PatternLayout->new("%d{E MMM d HH:mm:ss yyyy}: %m%n");
 my $appender = Log::Log4perl::Appender->new(
 	"Log::Dispatch::File",
 	name     => "rootConsoleFile",
-	filename => "$weathervaneHome/console.log",
-	mode     => "append",
+	filename => "$tmpDir/console.log",
+	mode     => "write",
 );
 $appender->layout($layout);
 $console_logger->add_appender($appender);
@@ -261,17 +335,18 @@ $layout   = Log::Log4perl::Layout::PatternLayout->new("%d %p> %F{1}:%L %M - %m%n
 $appender = Log::Log4perl::Appender->new(
 	"Log::Dispatch::File",
 	name     => "rootDebugFile",
-	filename => "$weathervaneHome/debug.log",
+	filename => "$tmpDir/debug.log",
 	mode     => "write",
 );
+$console_logger->add_appender($appender); #also send console_logger output to debug log
 $weathervane_logger->add_appender($appender);
 $appender->layout($layout);
 $appender = Log::Log4perl::Appender->new(
 	"Log::Dispatch::Screen",
 	name      => "rootWeathervaneScreen",
 	stderr    => 0,
-	threshold => "WARN",
 );
+$appender->threshold($WARN); #don't spam screen with DEBUG/INFO levels if they are enabled
 $weathervane_logger->add_appender($appender);
 $appender->layout($layout);
 
@@ -814,3 +889,7 @@ $console_logger->info( "Running Weathervane with "
 	  . $runManager->runProcedure->name
 	  . " RunProcedure.\n" );
 $runManager->start();
+
+my $resultsDir = "$outputDir/$seqnum";
+`mkdir -p $resultsDir`;
+`mv $tmpDir/* $resultsDir/.`;

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -330,7 +330,7 @@ $appender->layout($layout);
 $console_logger->add_appender($appender);
 
 my $weathervane_logger = get_logger("Weathervane");
-$weathervane_logger->level($WARN);
+$weathervane_logger->level($DEBUG);
 $layout   = Log::Log4perl::Layout::PatternLayout->new("%d %p> %F{1}:%L %M - %m%n");
 $appender = Log::Log4perl::Appender->new(
 	"Log::Dispatch::File",


### PR DESCRIPTION
WEAT-78 Record Debug Output (send console output to debug log, do not
write debug messages to screen)
WEAT-77 Early failures should still create output logs (send all
console/debug output to $tmpDir)
WEAT-80 Include more console output in console.log (send all console/debug
output to $tmpDir)
use hiearchical output structure - each run procedure creates a new subdir
under $tmpDir

Signed-off-by: Benjamin Hoflich <45051453+bhoflich@users.noreply.github.com>