### PR TITLE
Restrict config directories relative to current working directory

### DIFF
--- a/runHarness/AppInstance/AppInstance.pm
+++ b/runHarness/AppInstance/AppInstance.pm
@@ -143,21 +143,6 @@ override 'initialize' => sub {
 	$self->curRateStep( $self->getParamValue('initialRateStep') );
 	$self->minRateStep( $self->getParamValue('minRateStep') );
 
-	# if the distDir doesn't start with a / then it
-	# is relative to weathervaneHome
-	my $weathervaneHome = $self->getParamValue('weathervaneHome');
-	my $distDir         = $self->getParamValue('distDir');
-	if ( !( $distDir =~ /^\// ) ) {
-		$distDir = $weathervaneHome . "/" . $distDir;
-	}
-	$self->setParamValue( 'distDir', $distDir );
-
-	my $configDir  = $self->getParamValue('configDir');
-	if ( !( $configDir =~ /^\// ) ) {
-		$configDir = $weathervaneHome . "/" . $configDir;
-	}
-	$self->setParamValue('configDir', $configDir);
-
 	$self->users( $self->getParamValue('users') );
 	my $userLoadPath = $self->getParamValue('userLoadPath');
 	if ( $#$userLoadPath >= 0 ) {

--- a/runHarness/AppInstance/AuctionAppInstance.pm
+++ b/runHarness/AppInstance/AuctionAppInstance.pm
@@ -242,9 +242,6 @@ override 'redeploy' => sub {
 		", appInstance ",         $self->instanceNum
 	);
 
-	my $weathervaneHome = $self->getParamValue('weathervaneHome');
-	my $distDir         = $self->getParamValue('distDir');
-
 	# Refresh the docker images on all of the servers
 	$logger->debug("Redeploy by docker pull for services that are running on docker.");
 	my $workloadImpl    = $self->getParamValue('workloadImpl');

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -37,12 +37,6 @@ my $defaultUsersPerAuctionScaleFactor = 15.0;
 
 override 'initialize' => sub {
 	my ($self) = @_;
-	my $weathervaneHome = $self->getParamValue('weathervaneHome');
-	my $configDir  = $self->getParamValue('configDir');
-	if ( !( $configDir =~ /^\// ) ) {
-		$configDir = $weathervaneHome . "/" . $configDir;
-	}
-	$self->setParamValue('configDir', $configDir);
 
 	my $workloadNum = $self->appInstance->workload->instanceNum;
 	my $appInstanceNum = $self->appInstance->instanceNum;

--- a/runHarness/DataManagers/DataManager.pm
+++ b/runHarness/DataManagers/DataManager.pm
@@ -68,29 +68,6 @@ has 'portMap' => (
 override 'initialize' => sub {
 	my ( $self ) = @_;
 	
-	my $weathervaneHome = $self->getParamValue('weathervaneHome');
-	
-	# if the dbScriptDir doesn't start with a / then it
-	# is relative to weathervaneHome
-	my $dbScriptDir    = $self->getParamValue('dbScriptDir');
-	if ( !( $dbScriptDir =~ /^\// ) ) {
-		$dbScriptDir = $weathervaneHome . "/" . $dbScriptDir;
-	}
-	$self->setParamValue('dbScriptDir', $dbScriptDir);
-
-	# make sure the directories exist
-	if ( !( -e $dbScriptDir ) ) {
-		die "Error: The directory for the database creation scripts, $dbScriptDir, does not exist.";
-	}
-
-	# if the dbLoaderDir doesn't start with a / then it
-	# is relative to weathervaneHome
-	my $dbLoaderDir    = $self->getParamValue('dbLoaderDir' );
-	if ( !( $dbLoaderDir =~ /^\// ) ) {
-		$dbLoaderDir = $weathervaneHome . "/" . $dbLoaderDir;
-	}
-	$self->setParamValue('dbLoaderDir', $dbLoaderDir);
-
 	super();
 
 };

--- a/runHarness/Parameters.pm
+++ b/runHarness/Parameters.pm
@@ -38,6 +38,8 @@ my @nonInstanceListParameters = ('userLoadPath', 'kubernetesClusters', 'dockerHo
 								 'msgServerHosts', 'coordinationServerHosts', 'dbServerHosts', 'nosqlServerHosts');
 my @runLengthParams = ( 'steadyState', 'rampUp', 'rampDown'  );
 
+my @filterConstants = ( 'tmpDir' );
+
 sub getParamDefault {
 	my ($key) = @_;
 
@@ -62,8 +64,16 @@ sub getParamType {
 
 sub getParamKeys {
 	my @keys = keys %Parameters::parameters;
+	my @filteredKeys;
 
-	return \@keys;
+	foreach my $key (@keys) {
+		if ( !($key ~~ @filterConstants) ) {
+			push @filteredKeys, $key;
+		}
+	}
+
+	return \@filteredKeys;
+
 }
 
 sub getParentList {
@@ -174,7 +184,7 @@ sub setParamValue {
 }
 
 sub usage {
-	my @keys = keys %Parameters::parameters;
+	my @keys = @{getParamKeys()};
 	print "Usage:  ./weathervane.pl [options]\n";
 	foreach my $key (@keys) {
 		if ( $Parameters::parameters{$key}->{"showUsage"} ) {
@@ -187,8 +197,7 @@ sub usage {
 }
 
 sub fullUsage {
-
-	my @keys = keys %Parameters::parameters;
+	my @keys = @{getParamKeys()};
 	print "Usage:  ./weathervane.pl [options]\n";
 	my $i = 0;
 	foreach my $key (@keys) {
@@ -1075,7 +1084,7 @@ $parameters{"stopServices"} = {
 
 $parameters{"configFile"} = {
 	"type"    => "=s",
-	"default" => "/root/weathervane/weathervane.config",
+	"default" => "weathervane.config",
 	"parent"  => "",
 	"usageText" =>
 "This is the name of the Weathervane configuration file.\n\tIt must either include the full path to the file\n\tor be relative to the directory from which the script is run",
@@ -2420,23 +2429,13 @@ $parameters{"msgServerSuffix"} = {
 	"showUsage" => 0,
 };
 
-$parameters{"weathervaneHome"} = {
-	"type"    => "=s",
-	"default" => "/root/weathervane",
-	"parent"  => "",
-	"usageText" =>
-"This is the base directory under which the Weathervane harness expects to find its files.\n\tIf other directory related parameters are not diven with a full\n\tpath, they will be realative to this directory.",
-	"showUsage" => 1,
-};
-
-# If not absolute (starting with /) these directories are relative
-# to weathervaneHome
+# These directories are relative to the current working directory
 $parameters{"tmpDir"} = {
 	"type"    => "=s",
 	"default" => "tmpLog",
 	"parent"  => "runProc",
 	"usageText" =>
-"This is the directory in which Weathervane stores temporary files during a run.\n\tDo not use /tmp or any directory whose contents you wish to keep.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory in which Weathervane stores temporary files during a run relative to the current working directory.\n\tDo not use any directory whose contents you wish to keep.",
 	"showUsage" => 0,
 };
 $parameters{"outputDir"} = {
@@ -2444,15 +2443,15 @@ $parameters{"outputDir"} = {
 	"default" => "output",
 	"parent"  => "runProc",
 	"usageText" =>
-"This is the directory in which Weathervane stores the output from runs.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory in which Weathervane stores the output from runs relative to the current working directory.",
 	"showUsage" => 0,
 };
 $parameters{"sequenceNumberFile"} = {
 	"type"    => "=s",
-	"default" => "output/sequence.num",
+	"default" => "sequence.num",
 	"parent"  => "runProc",
 	"usageText" =>
-"This is the file that Weathervane uses to store the sequence number of the next run.\n\tIt must either include the full path to the file\n\tor be relative to weathervaneHome.",
+"This is the file that Weathervane uses to store the sequence number of the next run.",
 	"showUsage" => 0,
 };
 $parameters{"distDir"} = {
@@ -2460,7 +2459,7 @@ $parameters{"distDir"} = {
 	"default" => "dist",
 	"parent"  => "runProc",
 	"usageText" =>
-"This is the directory for the executables and other artifacts needed to run Weathervane.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory for the executables and other artifacts needed to run Weathervane relative to the current working directory.",
 	"showUsage" => 0,
 };
 $parameters{"dbScriptDir"} = {
@@ -2468,7 +2467,7 @@ $parameters{"dbScriptDir"} = {
 	"default" => "dist",
 	"parent"  => "appInstance",
 	"usageText" =>
-"This is the directory that contains the scripts used to configure the database tables.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory that contains the scripts used to configure the database tables relative to the current working directory.",
 	"showUsage" => 0,
 };
 $parameters{"dbLoaderDir"} = {
@@ -2476,7 +2475,7 @@ $parameters{"dbLoaderDir"} = {
 	"default" => "dist",
 	"parent"  => "dataManager",
 	"usageText" =>
-"This is the directory that contains the jar file for the DBLoader executable.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory that contains the jar file for the DBLoader executable relative to the current working directory.",
 	"showUsage" => 0,
 };
 $parameters{"workloadDriverDir"} = {
@@ -2484,7 +2483,7 @@ $parameters{"workloadDriverDir"} = {
 	"default" => "dist",
 	"parent"  => "workloadDriver",
 	"usageText" =>
-"This is the directory that contains the jar file for the workload-driver executable.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory that contains the jar file for the workload-driver executable relative to the current working directory.",
 	"showUsage" => 0,
 };
 $parameters{"workloadProfileDir"} = {
@@ -2492,7 +2491,7 @@ $parameters{"workloadProfileDir"} = {
 	"default" => "workloadConfiguration",
 	"parent"  => "workloadDriver",
 	"usageText" =>
-"This is the directory that contains the templates for the workload profiles.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory that contains the templates for the workload profiles relative to the current working directory.",
 	"showUsage" => 0,
 };
 $parameters{"gcviewerDir"} = {
@@ -2500,7 +2499,7 @@ $parameters{"gcviewerDir"} = {
 	"default" => "",
 	"parent"  => "runManager",
 	"usageText" =>
-"This is the path to the gcViewer executable.  GcViewer is used to\n\tanalyze the Java Garbage-Collection logs.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the path to the gcViewer executable relative to the current working directory.\n\tGcViewer is used to analyze the Java Garbage-Collection logs.",
 	"showUsage" => 0,
 };
 $parameters{"resultsFileDir"} = {
@@ -2508,7 +2507,7 @@ $parameters{"resultsFileDir"} = {
 	"default" => "",
 	"parent"  => "runManager",
 	"usageText" =>
-"This is the directory in which Weathervane stores the csv summary file.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory in which Weathervane stores the csv summary file relative to the current working directory.",
 	"showUsage" => 0,
 };
 $parameters{"resultsFileName"} = {
@@ -2516,7 +2515,7 @@ $parameters{"resultsFileName"} = {
 	"default" => "weathervaneResults.csv",
 	"parent"  => "runManager",
 	"usageText" =>
-"This is the name of the file in which Weathervane stores a summary of the run results in csv format.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the name of the file in which Weathervane stores a summary of the run results in csv format.",
 	"showUsage" => 1,
 };
 $parameters{"configDir"} = {
@@ -2524,7 +2523,7 @@ $parameters{"configDir"} = {
 	"default" => "configFiles",
 	"parent"  => "runManager",
 	"usageText" =>
-"This is the directory under which Weathervane stores\n\t configuration files for the various services.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory under which Weathervane stores configuration files for the various services relative to the current working directory.",
 	"showUsage" => 0,
 };
 $parameters{"dbLoaderImageDir"} = {
@@ -2532,7 +2531,7 @@ $parameters{"dbLoaderImageDir"} = {
 	"default" => "images",
 	"parent"  => "dataManager",
 	"usageText" =>
-"This is the directory in which the images used by the dbLoader are stored.\n\tIt must either include the full path to the directory\n\tor be relative to weathervaneHome.",
+"This is the directory in which the images used by the dbLoader are stored relative to the current working directory.",
 	"showUsage" => 0,
 };
 

--- a/runHarness/Parameters.pm
+++ b/runHarness/Parameters.pm
@@ -2462,14 +2462,6 @@ $parameters{"distDir"} = {
 "This is the directory for the executables and other artifacts needed to run Weathervane relative to the current working directory.",
 	"showUsage" => 0,
 };
-$parameters{"dbScriptDir"} = {
-	"type"    => "=s",
-	"default" => "dist",
-	"parent"  => "appInstance",
-	"usageText" =>
-"This is the directory that contains the scripts used to configure the database tables relative to the current working directory.",
-	"showUsage" => 0,
-};
 $parameters{"dbLoaderDir"} = {
 	"type"    => "=s",
 	"default" => "dist",
@@ -2524,14 +2516,6 @@ $parameters{"configDir"} = {
 	"parent"  => "runManager",
 	"usageText" =>
 "This is the directory under which Weathervane stores configuration files for the various services relative to the current working directory.",
-	"showUsage" => 0,
-};
-$parameters{"dbLoaderImageDir"} = {
-	"type"    => "=s",
-	"default" => "images",
-	"parent"  => "dataManager",
-	"usageText" =>
-"This is the directory in which the images used by the dbLoader are stored relative to the current working directory.",
 	"showUsage" => 0,
 };
 

--- a/runHarness/RunManagers/FixedRunManager.pm
+++ b/runHarness/RunManagers/FixedRunManager.pm
@@ -67,6 +67,7 @@ override 'start' => sub {
 
 	my $runProcedureType = $self->runProcedure->getRunProcedureImpl();
 	if ( $runProcedureType eq 'prepareOnly' ) {
+		$console_logger->info($runResult->toString());
 		$console_logger->info("Application configured and running.");
 	}
 	elsif ( $runProcedureType eq 'stop' ) {

--- a/runHarness/RunManagers/RunManager.pm
+++ b/runHarness/RunManagers/RunManager.pm
@@ -75,21 +75,6 @@ has 'resultsFileDir' => (
 
 override 'initialize' => sub {
 	my ( $self ) = @_;
-	my $paramHashRef = $self->paramHashRef;	
-
-	# if the resultsFileDir doesn't start with a / then it
-	# is relative to weathervaneHome
-	my $resultsFileDir = $paramHashRef->{'resultsFileDir' };
-	if ( !( $resultsFileDir =~ /^\// ) ) {
-		my $weathervaneHome =  $paramHashRef->{'weathervaneHome' };
-		if ( $resultsFileDir eq "" ) {
-			$resultsFileDir = $weathervaneHome;
-		}
-		else {
-			$resultsFileDir = $weathervaneHome . "/" . $resultsFileDir;
-		}
-	}
-	$paramHashRef->{'resultsFileDir' } = $resultsFileDir;
 
 	super();
 

--- a/runHarness/RunProcedures/LoadOnlyRunProcedure.pm
+++ b/runHarness/RunProcedures/LoadOnlyRunProcedure.pm
@@ -56,7 +56,6 @@ sub run {
 	my $tmpDir             = $self->getParamValue('tmpDir');
 	my $console_logger     = get_logger("Console");
 	my $debug_logger       = get_logger("Weathervane::RunProcedures::PrepareOnlyRunProcedure");
-	my $weathervaneHome    = $self->getParamValue('weathervaneHome');
 	my @pids;
 	my $pid;
 

--- a/runHarness/RunProcedures/PrepareOnlyRunProcedure.pm
+++ b/runHarness/RunProcedures/PrepareOnlyRunProcedure.pm
@@ -54,7 +54,6 @@ sub run {
 	my ( $self ) = @_;
 	my $majorSequenceNumberFile = $self->getParamValue('sequenceNumberFile');
 	my $tmpDir             = $self->getParamValue('tmpDir');
-	my $weathervaneHome    = $self->getParamValue('weathervaneHome');
 	my $console_logger     = get_logger("Console");
 	my $debug_logger       = get_logger("Weathervane::RunProcedures::PrepareOnlyRunProcedure");
 	my @pids;

--- a/runHarness/Services/Service.pm
+++ b/runHarness/Services/Service.pm
@@ -97,32 +97,6 @@ override 'initialize' => sub {
 	my $instanceNum = $self->instanceNum;
 	$self->name("${serviceType}W${workloadNum}A${appInstanceNum}I${instanceNum}");
 
-	my $weathervaneHome = $self->getParamValue('weathervaneHome');
-	my $configDir  = $self->getParamValue('configDir');
-	if ( !( $configDir =~ /^\// ) ) {
-		$configDir = $weathervaneHome . "/" . $configDir;
-	}
-	$self->setParamValue('configDir', $configDir);
-	
-	my $distDir  = $self->getParamValue( 'distDir' );
-	if ( !( $distDir =~ /^\// ) ) {
-		$distDir = $weathervaneHome . "/" . $distDir;
-	}
-	$self->setParamValue('distDir', $distDir);
-	
-	# if the dbScriptDir doesn't start with a / then it
-	# is relative to weathervaneHome
-	my $dbScriptDir    = $self->getParamValue('dbScriptDir' );
-	if ( !( $dbScriptDir =~ /^\// ) ) {
-		$dbScriptDir = $weathervaneHome . "/" . $dbScriptDir;
-	}
-	$self->setParamValue('dbScriptDir', $dbScriptDir);
-
-	# make sure the directories exist
-	if ( !( -e $dbScriptDir ) ) {
-		die "Error: The directory for the database creation scripts, $dbScriptDir, does not exist.";
-	}
-	
 	my $cpus = $self->getParamValue( $serviceType . "Cpus" );
 	my $mem = $self->getParamValue( $serviceType . "Mem" );
 	if ($self->getParamValue('dockerNet')) {

--- a/runHarness/Services/TomcatDockerService.pm
+++ b/runHarness/Services/TomcatDockerService.pm
@@ -396,11 +396,7 @@ sub getStatsSummary {
 	my ( $self, $statsLogPath, $users ) = @_;
 	tie( my %csv, 'Tie::IxHash' );
 
-	my $weathervaneHome = $self->getParamValue('weathervaneHome');
 	my $gcviewerDir     = $self->getParamValue('gcviewerDir');
-	if ( !( $gcviewerDir =~ /^\// ) ) {
-		$gcviewerDir = $weathervaneHome . "/" . $gcviewerDir;
-	}
 
 	# Only parseGc if gcviewer is present
 	if ( -f "$gcviewerDir/gcviewer-1.34-SNAPSHOT.jar" ) {

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -164,15 +164,6 @@ override 'initialize' => sub {
 	my ( $self, $paramHashRef ) = @_;
 	super();
 
-	# if the workloadProfileDir doesn't start with a / then it
-	# is relative to weathervaneHome
-	my $weathervaneHome    = $self->getParamValue('weathervaneHome');
-	my $workloadProfileDir = $self->getParamValue('workloadProfileDir');
-	if ( !( $workloadProfileDir =~ /^\// ) ) {
-		$workloadProfileDir = $weathervaneHome . "/" . $workloadProfileDir;
-	}
-	$self->setParamValue( 'workloadProfileDir', $workloadProfileDir );
-
 };
 
 override 'addSecondary' => sub {
@@ -1684,11 +1675,7 @@ sub getStatsSummary {
 		return;	
 	}
 
-	my $weathervaneHome = $self->getParamValue('weathervaneHome');
 	my $gcviewerDir     = $self->getParamValue('gcviewerDir');
-	if ( !( $gcviewerDir =~ /^\// ) ) {
-		$gcviewerDir = $weathervaneHome . "/" . $gcviewerDir;
-	}
 
 	# Only parseGc if gcviewer is present
 	if ( -f "$gcviewerDir/gcviewer-1.34-SNAPSHOT.jar" ) {

--- a/runHarness/WorkloadDrivers/WorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/WorkloadDriver.pm
@@ -67,26 +67,12 @@ has 'portMap' => (
 
 override 'initialize' => sub {
 	my ( $self ) = @_;
-	my $paramHashRef = $self->paramHashRef;
 	
 	# Assign a name to this driver
 	my $workloadNum = $self->workload->instanceNum;
 	my $instanceNum = $self->instanceNum;
 	$self->name("driverW${workloadNum}I${instanceNum}");
 
-	my $weathervaneHome        = $paramHashRef->{ 'weathervaneHome' };
-	my $workloadDriverDir = $self->getParamValue('workloadDriverDir');
-	if ( !( $workloadDriverDir =~ /^\// ) ) {
-		$workloadDriverDir = $weathervaneHome . "/" . $workloadDriverDir;
-	}
-	$self->setParamValue( 'workloadDriverDir', $workloadDriverDir );
-
-	my $distDir = $self->getParamValue('distDir' );
-	if ( !( $distDir =~ /^\// ) ) {
-		$distDir = $weathervaneHome . "/" . $distDir;
-	}
-	$self->setParamValue( 'distDir', $distDir );
-	
 	super();
 
 };

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -345,10 +345,6 @@ my $configDir = getParamValue( $paramsHashRef, 'configDir');
 $configDir = $weathervaneHome . "/" . $configDir;
 setParamValue( $paramsHashRef, 'configDir', $configDir);
 
-my $dbScriptDir = getParamValue( $paramsHashRef, 'dbScriptDir' );
-$dbScriptDir = $weathervaneHome . "/" . $dbScriptDir;
-setParamValue( $paramsHashRef, 'dbScriptDir', $dbScriptDir);
-
 my $dbLoaderDir = getParamValue( $paramsHashRef, 'dbLoaderDir' );
 $dbLoaderDir = $weathervaneHome . "/" . $dbLoaderDir;
 setParamValue( $paramsHashRef, 'dbLoaderDir', $dbLoaderDir);
@@ -380,9 +376,6 @@ setParamValue( $paramsHashRef,  'gcviewerDir', $gcviewerDir );
 # Make sure required directories exist
 if ( !( -e $outputDir ) ) {
 	`mkdir -p $outputDir`;
-}
-if ( !( -e $dbScriptDir ) ) {
-	die "Error: The directory for the database creation scripts, $dbScriptDir, does not exist.";
 }
 
 # Get the sequence number of the next run

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -28,10 +28,12 @@ use FileHandle;
 use Statistics::Descriptive;
 use Switch;
 use Log::Log4perl qw(get_logger :levels);
+use Cwd qw();
 
 no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
-use lib '/root/weathervane/runHarness';
+use File::Basename;
+use lib dirname (__FILE__) . '/runHarness';
 
 use Factories::ServiceFactory;
 use Factories::HostFactory;
@@ -173,155 +175,21 @@ sub getComputeResourceForInstance {
 	}
 }
 
-# read in the command-line options
-my %paramCommandLine = ();
-my @paramStrings     = ();
-my @validParams      = ();
-my $keysRef          = getParamKeys();
-foreach my $key (@$keysRef) {
-	my $type = getParamType($key);
-	push @validParams, $key;
-	if ( ( $type eq "hash" ) || ( $type eq "list" ) ) {
-		next;
-	}
-	push @paramStrings, $key . $type;
-}
-GetOptions( \%paramCommandLine, @paramStrings );
-
-# If there is a "users" parameter on the command-line, turn it
-# into list of values for the different appInstances.  The values are
-# assigned to the appInstances in order.  If there are too few, then
-# the remaining appInstances get the values from the configFile or the default.
-# If there are too many then the extras are ignored.
-my @usersList;
-if ( exists $paramCommandLine{'users'} ) {
-	@usersList = split( ',', $paramCommandLine{'users'} );
+# Set weathervaneHome to the current working directory
+my $weathervaneHome = Cwd::cwd();
+if ( !( -e "$weathervaneHome/weathervane.pl" ) ) {
+	die "weathervane.pl does not exist in the current working directory.\n"
 }
 
-# Figure out where to read the config file
-my $configFileName;
-if ( exists( $paramCommandLine{'configFile'} ) ) {
-	$configFileName = $paramCommandLine{'configFile'};
-}
-else {
-	$configFileName = getParamDefault('configFile');
-}
-
-# Read in the config file
-open( CONFIGFILE, "<$configFileName" ) or die "Couldn't Open $configFileName: $!\n";
-my $json = JSON->new;
-$json = $json->relaxed(1);
-$json = $json->pretty(1);
-$json = $json->max_depth(4096);
-
-my $paramJson = "";
-while (<CONFIGFILE>) {
-	$paramJson .= $_;
-}
-close CONFIGFILE;
-
-my $paramConfig = $json->decode($paramJson);
-
-# Make sure that all of the parameters read from the config file are valid
-foreach my $key ( keys %$paramConfig ) {
-	if ( !( $key ~~ @validParams ) ) {
-		die "Parameter $key in configuration file $configFileName is not a valid parameter";
-	}
-}
-
-my $paramsHashRef = mergeParameters( \%paramCommandLine, $paramConfig );
-
-# Read in the fixed configuration
-open( FIXEDCONFIGFILE, "<./runHarness/fixedConfigs.json" ) or die "Couldn't Open fixedConfigs.json: $!\n";
-$paramJson = "";
-while (<FIXEDCONFIGFILE>) {
-	$paramJson .= $_;
-}
-close FIXEDCONFIGFILE;
-my $fixedConfigs = $json->decode($paramJson);
-
-my $weathervaneHome = getParamValue( $paramsHashRef, 'weathervaneHome' );
-
-# if the tmpDir doesn't start with a / then it
-# is relative to weathervaneHome
-my $tmpDir = getParamValue( $paramsHashRef, 'tmpDir');
-if ( !( $tmpDir =~ /^\// ) ) {
-	$tmpDir = $weathervaneHome . "/" . $tmpDir;
-}
-setParamValue( $paramsHashRef, 'tmpDir', $tmpDir );
-
-# if the outputDir doesn't start with a / then it
-# is relative to weathervaneHome
-my $outputDir = getParamValue( $paramsHashRef, 'outputDir' );
-if ( !( $outputDir =~ /^\// ) ) {
-	$outputDir = $weathervaneHome . "/" . $outputDir;
-}
-setParamValue( $paramsHashRef, 'outputDir', $outputDir );
-
-# if the distDir doesn't start with a / then it
-# is relative to weathervaneHome
-my $distDir         = getParamValue( $paramsHashRef, 'distDir' );
-if ( !( $distDir =~ /^\// ) ) {
-	$distDir = $weathervaneHome . "/" . $distDir;
-}
-setParamValue( $paramsHashRef, 'distDir', $distDir );
-
-# if the sequenceNumberFile doesn't start with a / then it
-# is relative to weathervaneHome
-my $sequenceNumberFile = getParamValue( $paramsHashRef, 'sequenceNumberFile' );
-if ( !( $sequenceNumberFile =~ /^\// ) ) {
-	$sequenceNumberFile = $weathervaneHome . "/" . $sequenceNumberFile;
-}
-setParamValue( $paramsHashRef, 'sequenceNumberFile', $sequenceNumberFile );
-
-# make sure the directories exist
+# For $tmpDir, use Parameters.pm default relative to weathervaneHome,
+# make sure its exists, and clean it out.
+my $tmpDir = getParamDefault('tmpDir');
+$tmpDir = $weathervaneHome . "/" . $tmpDir;
 if ( !( -e $tmpDir ) ) {
 	`mkdir $tmpDir`;
+} else {
+	`rm -r $tmpDir/* 2>&1`;
 }
-
-if ( !( -e $outputDir ) ) {
-	`mkdir -p $outputDir`;
-}
-
-# Get the sequence number of the next run
-my $seqnum;
-if ( -e "$sequenceNumberFile" ) {
-	open SEQFILE, "<$sequenceNumberFile";
-	$seqnum = <SEQFILE>;
-	close SEQFILE;
-	if ( -e "$outputDir/$seqnum" ) {
-		print "Next run number is $seqnum, but directory for run $seqnum already exists in $outputDir\n";
-		exit -1;
-	}
-	open SEQFILE, ">$sequenceNumberFile";
-	my $nextSeqNum = $seqnum + 1;
-	print SEQFILE $nextSeqNum;
-	close SEQFILE;
-}
-else {
-	if ( -e "$outputDir/0" ) {
-		print "Sequence number file is missing, but run 0 already exists in $outputDir\n";
-		exit -1;
-	}
-	$seqnum = 0;
-	open SEQFILE, ">$sequenceNumberFile";
-	my $nextSeqNum = 1;
-	print SEQFILE $nextSeqNum;
-	close SEQFILE;
-}
-
-#clean out the tmp directory
-`rm -r $tmpDir/* 2>&1`;
-
-# Copy the version file into the output directory
-`cp $weathervaneHome/version.txt $tmpDir/version.txt`;
-
-# Save the original config file and processed command line parameters 
-`cp $configFileName $tmpDir/$configFileName.save`;
-
-open PARAMCOMMANDLINEFILE, ">$tmpDir/paramCommandLine.save";
-print PARAMCOMMANDLINEFILE $json->encode(\%paramCommandLine);
-close PARAMCOMMANDLINEFILE;
 
 # Set up the loggers
 my $console_logger = get_logger("Console");
@@ -364,18 +232,195 @@ $appender->threshold($WARN); #don't spam screen with DEBUG/INFO levels if they a
 $weathervane_logger->add_appender($appender);
 $appender->layout($layout);
 
+tie *STDERR, "StderrToLogerror", category => "Console";
+my $logger = get_logger("Weathervane");
+
+# read in the command-line options
+my %paramCommandLine = ();
+my @paramStrings     = ();
+my @validParams      = ();
+my $keysRef          = getParamKeys();
+foreach my $key (@$keysRef) {
+	my $type = getParamType($key);
+	push @validParams, $key;
+	if ( ( $type eq "hash" ) || ( $type eq "list" ) ) {
+		next;
+	}
+	push @paramStrings, $key . $type;
+}
+GetOptions( \%paramCommandLine, @paramStrings );
+
+# Check for a request for the help text
+if ( exists $paramCommandLine{'help'} ) {
+	usage();
+	exit;
+}
+
+# Check for a request for the help text
+if ( exists $paramCommandLine{'fullHelp'} ) {
+	fullUsage();
+	exit;
+}
+
+# If there is a "users" parameter on the command-line, turn it
+# into list of values for the different appInstances.  The values are
+# assigned to the appInstances in order.  If there are too few, then
+# the remaining appInstances get the values from the configFile or the default.
+# If there are too many then the extras are ignored.
+my @usersList;
+if ( exists $paramCommandLine{'users'} ) {
+	@usersList = split( ',', $paramCommandLine{'users'} );
+}
+
+# Figure out where to read the config file
+my $configFileName;
+if ( exists( $paramCommandLine{'configFile'} ) ) {
+	$configFileName = $paramCommandLine{'configFile'};
+}
+else {
+	$configFileName = getParamDefault('configFile');
+	$configFileName = $weathervaneHome . "/" . $configFileName;
+}
+
+# Read in the config file
+open( CONFIGFILE, "<$configFileName" ) or die "Couldn't Open $configFileName: $!\n";
+my $json = JSON->new;
+$json = $json->relaxed(1);
+$json = $json->pretty(1);
+$json = $json->max_depth(4096);
+
+my $paramJson = "";
+while (<CONFIGFILE>) {
+	$paramJson .= $_;
+}
+close CONFIGFILE;
+
+my $paramConfig = $json->decode($paramJson);
+
+# Make sure that all of the parameters read from the config file are valid
+foreach my $key ( keys %$paramConfig ) {
+	if ( !( $key ~~ @validParams ) ) {
+		die "Parameter $key in configuration file $configFileName is not a valid parameter";
+	}
+}
+
+my $paramsHashRef = mergeParameters( \%paramCommandLine, $paramConfig );
+
+# $tmpdir was set above, add to $paramsHashRef
+setParamValue( $paramsHashRef, 'tmpDir', $tmpDir );
+
+# Read in the fixed configuration
+open( FIXEDCONFIGFILE, "<$weathervaneHome/runHarness/fixedConfigs.json" ) or die "Couldn't Open fixedConfigs.json: $!\n";
+$paramJson = "";
+while (<FIXEDCONFIGFILE>) {
+	$paramJson .= $_;
+}
+close FIXEDCONFIGFILE;
+my $fixedConfigs = $json->decode($paramJson);
+
+# Update logger levels based on config
 if ( getParamValue( $paramsHashRef, "loggers" ) ) {
 	my $loggersHashRef = getParamValue( $paramsHashRef, "loggers" );
 	my @keys = keys %$loggersHashRef;
 	foreach my $loggerName ( keys %$loggersHashRef ) {
-		my $logger = get_logger($loggerName);
-		$logger->level( $loggersHashRef->{$loggerName} );
+		my $loggerInst = get_logger($loggerName);
+		$loggerInst->level( $loggersHashRef->{$loggerName} );
 	}
 }
 
-tie *STDERR, "StderrToLogerror", category => "Console";
+# Set dirs relative to weathervaneHome
+my $outputDir = getParamValue( $paramsHashRef, 'outputDir' );
+$outputDir = $weathervaneHome . "/" . $outputDir;
+setParamValue( $paramsHashRef, 'outputDir', $outputDir );
 
-my $logger = get_logger("Weathervane");
+my $distDir         = getParamValue( $paramsHashRef, 'distDir' );
+$distDir = $weathervaneHome . "/" . $distDir;
+setParamValue( $paramsHashRef, 'distDir', $distDir );
+
+my $sequenceNumberFile = getParamValue( $paramsHashRef, 'sequenceNumberFile' );
+$sequenceNumberFile = $outputDir . "/" . $sequenceNumberFile;
+setParamValue( $paramsHashRef, 'sequenceNumberFile', $sequenceNumberFile );
+
+my $configDir = getParamValue( $paramsHashRef, 'configDir');
+$configDir = $weathervaneHome . "/" . $configDir;
+setParamValue( $paramsHashRef, 'configDir', $configDir);
+
+my $dbScriptDir = getParamValue( $paramsHashRef, 'dbScriptDir' );
+$dbScriptDir = $weathervaneHome . "/" . $dbScriptDir;
+setParamValue( $paramsHashRef, 'dbScriptDir', $dbScriptDir);
+
+my $dbLoaderDir = getParamValue( $paramsHashRef, 'dbLoaderDir' );
+$dbLoaderDir = $weathervaneHome . "/" . $dbLoaderDir;
+setParamValue( $paramsHashRef, 'dbLoaderDir', $dbLoaderDir);
+
+my $resultsFileDir = getParamValue( $paramsHashRef, 'resultsFileDir' );
+if ( $resultsFileDir eq "" ) {
+	$resultsFileDir = $weathervaneHome;
+}
+else {
+	$resultsFileDir = $weathervaneHome . "/" . $resultsFileDir;
+	if ( !( -e $resultsFileDir ) ) {
+		`mkdir -p $resultsFileDir`;
+	}
+}
+setParamValue( $paramsHashRef,  'resultsFileDir', $resultsFileDir );
+
+my $workloadDriverDir = getParamValue( $paramsHashRef, 'workloadDriverDir');
+$workloadDriverDir = $weathervaneHome . "/" . $workloadDriverDir;
+setParamValue( $paramsHashRef,  'workloadDriverDir', $workloadDriverDir );
+
+my $workloadProfileDir = getParamValue( $paramsHashRef, 'workloadProfileDir');
+$workloadProfileDir = $weathervaneHome . "/" . $workloadProfileDir;
+setParamValue( $paramsHashRef,  'workloadProfileDir', $workloadProfileDir );
+
+my $gcviewerDir = getParamValue( $paramsHashRef, 'gcviewerDir');
+$gcviewerDir = $weathervaneHome . "/" . $gcviewerDir;
+setParamValue( $paramsHashRef,  'gcviewerDir', $gcviewerDir );
+
+# Make sure required directories exist
+if ( !( -e $outputDir ) ) {
+	`mkdir -p $outputDir`;
+}
+if ( !( -e $dbScriptDir ) ) {
+	die "Error: The directory for the database creation scripts, $dbScriptDir, does not exist.";
+}
+
+# Get the sequence number of the next run
+my $seqnum;
+if ( -e "$sequenceNumberFile" ) {
+	open SEQFILE, "<$sequenceNumberFile";
+	$seqnum = <SEQFILE>;
+	close SEQFILE;
+	if ( -e "$outputDir/$seqnum" ) {
+		print "Next run number is $seqnum, but directory for run $seqnum already exists in $outputDir\n";
+		exit -1;
+	}
+	open SEQFILE, ">$sequenceNumberFile";
+	my $nextSeqNum = $seqnum + 1;
+	print SEQFILE $nextSeqNum;
+	close SEQFILE;
+}
+else {
+	if ( -e "$outputDir/0" ) {
+		print "Sequence number file is missing, but run 0 already exists in $outputDir\n";
+		exit -1;
+	}
+	$seqnum = 0;
+	open SEQFILE, ">$sequenceNumberFile";
+	my $nextSeqNum = 1;
+	print SEQFILE $nextSeqNum;
+	close SEQFILE;
+}
+
+# Copy the version file into the output directory
+`cp $weathervaneHome/version.txt $tmpDir/version.txt`;
+
+# Save the original config file and processed command line parameters
+my $saveConfigFile = $tmpDir . "/" . basename($configFileName) . ".save";
+`cp $configFileName $saveConfigFile`;
+open PARAMCOMMANDLINEFILE, ">$tmpDir/paramCommandLine.save";
+print PARAMCOMMANDLINEFILE $json->encode(\%paramCommandLine);
+close PARAMCOMMANDLINEFILE;
 
 # set the run length parameters properly
 my $runLength   = getParamValue( $paramsHashRef, "runLength" );


### PR DESCRIPTION
Set weathervaneHome to the current working directory
Adjust use lib for 'runHarness' to be relative to weathervane.pl
Use Parameters.pm default for $tmpDir and make it a constant
Move all relative path adjustments to weathervane.pl
Move logger setup to top of weathervane.pl script
Move help usage code up in weathervane.pl to be more usable
Print run number also with prepareOnly

Signed-off-by: Benjamin Hoflich <45051453+bhoflich@users.noreply.github.com>

notes:
There is still usage of /tmp.
Only $tmpDir is a 'fixed' location, but all other config directories are now relative to cwd.