### PR TITLE
Hrosenbe/disable warmer

### DIFF
--- a/auctionApp/src/main/java/com/vmware/weathervane/auction/service/CacheWarmerServiceImpl.java
+++ b/auctionApp/src/main/java/com/vmware/weathervane/auction/service/CacheWarmerServiceImpl.java
@@ -59,7 +59,7 @@ public class CacheWarmerServiceImpl implements CacheWarmerService {
 
 	@Inject
 	@Named("auctionDao")
-	AuctionDao auctionDao;
+	AuctionDao auctionDao;	
 
 	private boolean cachesWarmed = false;
 	private AtomicBoolean warmerRun = new AtomicBoolean(false);
@@ -71,9 +71,16 @@ public class CacheWarmerServiceImpl implements CacheWarmerService {
 	@Override
 	public boolean isReady() {
 		if (!warmerRun.getAndSet(true)) {
-			// Start the cache warmer on the first healthCheck
-			Thread warmerThread = new Thread(new CacheWarmingRunner(), "cacheWarmer");
-			warmerThread.start();
+			Boolean preWarm = Boolean.getBoolean("PREWARM");
+			if (preWarm) {
+				logger.warn("Prewarming caches");
+				// Start the cache warmer on the first healthCheck
+				Thread warmerThread = new Thread(new CacheWarmingRunner(), "cacheWarmer");
+				warmerThread.start();
+			} else {
+				logger.warn("Not prewarming caches");
+				cachesWarmed = true;
+			}
 		}
 		return cachesWarmed;
 	}

--- a/configFiles/kubernetes/auctionbidservice.yaml
+++ b/configFiles/kubernetes/auctionbidservice.yaml
@@ -91,7 +91,6 @@ spec:
           exec:
             command:
             - /bin/sh
-            - -i
             - -c
             - 'curl -s http://127.0.0.1:8080/auction/healthCheck | grep -Eq alive'
           failureThreshold: 3

--- a/configFiles/kubernetes/auctionworkloadcontroller.yaml
+++ b/configFiles/kubernetes/auctionworkloadcontroller.yaml
@@ -79,7 +79,6 @@ spec:
           exec:
             command:
             - /bin/sh
-            - -i
             - -c
             - 'curl -s http://127.0.0.1:80/driver/up | grep -Eq true'
           failureThreshold: 3

--- a/configFiles/kubernetes/cassandra.yaml
+++ b/configFiles/kubernetes/cassandra.yaml
@@ -98,7 +98,6 @@ spec:
           exec:
             command:
             - /bin/sh
-            - -i
             - -c
             - 'nodetool status | grep $POD_IP | grep -Eq UN'
           initialDelaySeconds: 15

--- a/configFiles/kubernetes/nginx.yaml
+++ b/configFiles/kubernetes/nginx.yaml
@@ -87,7 +87,6 @@ spec:
           exec:
             command:
             - /bin/sh
-            - -i
             - -c
             - 'curl -s -w "%{http_code}\n" -o /dev/null http://127.0.0.1:80'
           failureThreshold: 3

--- a/configFiles/kubernetes/postgresql.yaml
+++ b/configFiles/kubernetes/postgresql.yaml
@@ -87,7 +87,6 @@ spec:
           exec:
             command:
             - /bin/sh
-            - -i
             - -c
             - 'cat /tmp/isReady && /usr/pgsql-9.3/bin/pg_isready -h 127.0.0.1 -p 5432'
           failureThreshold: 3

--- a/configFiles/kubernetes/rabbitmq.yaml
+++ b/configFiles/kubernetes/rabbitmq.yaml
@@ -79,7 +79,6 @@ spec:
           exec:
             command:
             - /bin/sh
-            - -i
             - -c
             - 'curl -f --user auction:auction 127.0.0.1:15672/api/healthchecks/node | grep -Eq ok'
           failureThreshold: 3

--- a/configFiles/kubernetes/tomcat.yaml
+++ b/configFiles/kubernetes/tomcat.yaml
@@ -97,7 +97,6 @@ spec:
           exec:
             command:
             - /bin/sh
-            - -i
             - -c
             - 'curl -s http://127.0.0.1:8080/auction/healthCheck | grep -Eq alive'
           failureThreshold: 3

--- a/runHarness/AppInstance/AuctionAppInstance.pm
+++ b/runHarness/AppInstance/AuctionAppInstance.pm
@@ -378,6 +378,11 @@ sub getServiceConfigParameters {
 		$jvmOpts .= " -DAUCTIONREPRESENTATIONCACHESIZE=$auctionRepresentationCacheSize ";
 		$jvmOpts .= " -DIMAGEINFOCACHESIZE=$imageInfoCacheSize -DITEMSFORAUCTIONCACHESIZE=$itemsForAuctionCacheSize ";
 		$jvmOpts .= " -DITEMCACHESIZE=$itemCacheSize ";
+		if ($self->getParamValue('prewarmAppServers')) {
+			$jvmOpts .= " -DPREWARM=true ";
+		} else {
+			$jvmOpts .= " -DPREWARM=false ";	
+		}
 
 		my $zookeeperConnectionString = "";
 		my $coordinationServersRef    = $self->getAllServicesByType('coordinationServer');

--- a/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
+++ b/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
@@ -200,7 +200,11 @@ override 'getServiceConfigParameters' => sub {
 		$jvmOpts .= " -DAUCTIONREPRESENTATIONCACHESIZE=$auctionRepresentationCacheSize ";
 		$jvmOpts .= " -DIMAGEINFOCACHESIZE=$imageInfoCacheSize -DITEMSFORAUCTIONCACHESIZE=$itemsForAuctionCacheSize ";
 		$jvmOpts .= " -DITEMCACHESIZE=$itemCacheSize ";
-
+		if ($self->getParamValue('prewarmAppServers')) {
+			$jvmOpts .= " -DPREWARM=true ";
+		} else {
+			$jvmOpts .= " -DPREWARM=false ";	
+		}
 
 		my $zookeeperConnectionString = "";
 		my $numCoordinationServers   = $self->getTotalNumOfServiceType('coordinationServer');

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-2.0.3-dev
+removeWarmer

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-removeWarmer
+2.0.3-dev

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -512,6 +512,7 @@ if ($fullHelp) {
 }
 
 my $version = `cat $weathervaneHome/version.txt`;
+chomp($version);
 $console_logger->warn( "Weathervane Version $version" );
 if (!getParamValue($paramsHashRef, "dockerWeathervaneVersion")) {	
 	setParamValue( $paramsHashRef, "dockerWeathervaneVersion",  $version );


### PR DESCRIPTION
This pull request includes the following changes:
- The _prewarmAppServers_ parameter can be used to disable pre-warming of the app servers. This has been tested for functionality, but not for the impact on performance.  As a result this feature will be undocumented.  Its purpose is to enable debugging if we think that the pre-warming is preventing runs from starting.  We will test the performance impact at a later time.
- The -i has been removed from the readiness probes.  They were unnecessary, and may have been causing problems.