### PR TITLE
use context in AuctionKubernetesDataManager calls to kubectl

### DIFF
--- a/dockerImages/auctiondatamanager/isDataLoaded.pl
+++ b/dockerImages/auctiondatamanager/isDataLoaded.pl
@@ -6,7 +6,7 @@ use strict;
 use POSIX;
 
 my $appInstanceNum = $ENV{'APPINSTANCENUM'};
-print "Cleaning data for appInstance $appInstanceNum\n";
+print "Checking whether data is loaded for appInstance $appInstanceNum\n";
 
 # Not preparing any auctions, just cleaning up
 my $auctions = 0;


### PR DESCRIPTION
Changes in this pull request:
- The calls to kubectl in AuctionKubernetesDataManager were not using the context defined for the KubernetesCluster, and instead were just getting the current-context from the kubeconfig file.  This fixes that bug.

Signed-off-by: Hal Rosenberg <hrosenbe@vmware.com>