### PR TITLE
Explicitly delete deployments, etc rather than using all

### DIFF
--- a/runHarness/ComputeResources/KubernetesCluster.pm
+++ b/runHarness/ComputeResources/KubernetesCluster.pm
@@ -314,49 +314,60 @@ sub kubernetesDeleteAllWithLabel {
 	if ($cmdFailed) {
 		$logger->error("kubernetesDeleteAllWithLabel delete deployments failed: $cmdFailed");
 	}
-	$logger->debug("Command: $cmd");
-	$logger->debug("Output: $outString");
-
+	if ($outString  && !($outString =~ /No\sresources\sfound/)) {
+		$logger->debug("Command: $cmd");
+		$logger->debug("Output: $outString");
+	}
+	
 	$cmd = "kubectl delete sts --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
 	($cmdFailed, $outString) = runCmd($cmd);
 	if ($cmdFailed) {
 		$logger->error("kubernetesDeleteAllWithLabel delete sts failed: $cmdFailed");
 	}
-	$logger->debug("Command: $cmd");
-	$logger->debug("Output: $outString");
-
+	if ($outString  && !($outString =~ /No\sresources\sfound/)) {
+		$logger->debug("Command: $cmd");
+		$logger->debug("Output: $outString");
+	}
+	
 	$cmd = "kubectl delete daemonsets --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
 	($cmdFailed, $outString) = runCmd($cmd);
 	if ($cmdFailed) {
 		$logger->error("kubernetesDeleteAllWithLabel delete daemonsets failed: $cmdFailed");
 	}
-	$logger->debug("Command: $cmd");
-	$logger->debug("Output: $outString");
-
+	if ($outString  && !($outString =~ /No\sresources\sfound/)) {
+		$logger->debug("Command: $cmd");
+		$logger->debug("Output: $outString");
+	}
+	
 	$cmd = "kubectl delete replicasets --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
 	($cmdFailed, $outString) = runCmd($cmd);
 	if ($cmdFailed) {
 		$logger->error("kubernetesDeleteAllWithLabel delete replicasets failed: $cmdFailed");
 	}
-	$logger->debug("Command: $cmd");
-	$logger->debug("Output: $outString");
-
+	if ($outString  && !($outString =~ /No\sresources\sfound/)) {
+		$logger->debug("Command: $cmd");
+		$logger->debug("Output: $outString");
+	}
+	
 	$cmd = "kubectl delete service --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
 	($cmdFailed, $outString) = runCmd($cmd);
 	if ($cmdFailed) {
 		$logger->error("kubernetesDeleteAllWithLabel delete service failed: $cmdFailed");
 	}
-	$logger->debug("Command: $cmd");
-	$logger->debug("Output: $outString");
-
+	if ($outString  && !($outString =~ /No\sresources\sfound/)) {
+		$logger->debug("Command: $cmd");
+		$logger->debug("Output: $outString");
+	}
+	
 	$cmd = "kubectl delete configmap --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
 	($cmdFailed, $outString) = runCmd($cmd);
 	if ($cmdFailed) {
 		$logger->error("kubernetesDeleteAllWithLabel delete configmap failed: $cmdFailed");
 	}
-	$logger->debug("Command: $cmd");
-	$logger->debug("Output: $outString");
-	
+	if ($outString  && !($outString =~ /No\sresources\sfound/)) {
+		$logger->debug("Command: $cmd");
+		$logger->debug("Output: $outString");
+	}
 }
 
 sub kubernetesDeleteAllWithLabelAndResourceType {

--- a/runHarness/ComputeResources/KubernetesCluster.pm
+++ b/runHarness/ComputeResources/KubernetesCluster.pm
@@ -309,13 +309,46 @@ sub kubernetesDeleteAllWithLabel {
 	my $cmd;
 	my $outString;
 	my $cmdFailed;
-	$cmd = "kubectl delete all --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
+	$cmd = "kubectl delete deployments --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
 	($cmdFailed, $outString) = runCmd($cmd);
 	if ($cmdFailed) {
-		$logger->error("kubernetesDeleteAllWithLabel delete all failed: $cmdFailed");
+		$logger->error("kubernetesDeleteAllWithLabel delete deployments failed: $cmdFailed");
 	}
 	$logger->debug("Command: $cmd");
 	$logger->debug("Output: $outString");
+
+	$cmd = "kubectl delete sts --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
+	($cmdFailed, $outString) = runCmd($cmd);
+	if ($cmdFailed) {
+		$logger->error("kubernetesDeleteAllWithLabel delete sts failed: $cmdFailed");
+	}
+	$logger->debug("Command: $cmd");
+	$logger->debug("Output: $outString");
+
+	$cmd = "kubectl delete daemonsets --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
+	($cmdFailed, $outString) = runCmd($cmd);
+	if ($cmdFailed) {
+		$logger->error("kubernetesDeleteAllWithLabel delete daemonsets failed: $cmdFailed");
+	}
+	$logger->debug("Command: $cmd");
+	$logger->debug("Output: $outString");
+
+	$cmd = "kubectl delete replicasets --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
+	($cmdFailed, $outString) = runCmd($cmd);
+	if ($cmdFailed) {
+		$logger->error("kubernetesDeleteAllWithLabel delete replicasets failed: $cmdFailed");
+	}
+	$logger->debug("Command: $cmd");
+	$logger->debug("Output: $outString");
+
+	$cmd = "kubectl delete service --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
+	($cmdFailed, $outString) = runCmd($cmd);
+	if ($cmdFailed) {
+		$logger->error("kubernetesDeleteAllWithLabel delete service failed: $cmdFailed");
+	}
+	$logger->debug("Command: $cmd");
+	$logger->debug("Output: $outString");
+
 	$cmd = "kubectl delete configmap --selector=$selector --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
 	($cmdFailed, $outString) = runCmd($cmd);
 	if ($cmdFailed) {

--- a/runHarness/WorkloadDrivers/AuctionKubernetesWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionKubernetesWorkloadDriver.pm
@@ -321,7 +321,7 @@ override 'doHttpGet' => sub {
 	my $logger         = get_logger("Weathervane::WorkloadDrivers::AuctionKubernetesWorkloadDriver");
 	$logger->debug("doHttpGet: Sending Get to $url.");
 	
-	my $cmd = "http --pretty none --print hb --timeout 120 GET $url";
+	my $cmd = "http --pretty none --print hb --timeout 120 --ignore-stdin GET $url";
 	my $cluster = $self->host;
 	my ($cmdFailed, $outString) = $cluster->kubernetesExecOne("wkldcontroller", $cmd, $self->namespace);
 	if ($cmdFailed) {


### PR DESCRIPTION
Changes in this pull request:
- Rather than using `delete all` when cleaning up after a run, explicitly delete all constructs that might have been created by Weathervane.  Let Kubernetes deleted the pods.  Note that this change issues a delete for some kinds of objects (such as daemonsets) that are not currently used by Weathervane, but that may be in the future.

Signed-off-by: Hal Rosenberg <hrosenbe@vmware.com>