### PR TITLE
doc updates  related to prereqs

### DIFF
--- a/doc/userDocs/usersGuide.md
+++ b/doc/userDocs/usersGuide.md
@@ -314,7 +314,7 @@ auction and item data, item images, and historical event data regarding bids
 and auction attendance.
 
 There must be at least one [StorageClass](#storageclass) defined on the application cluster to be used for this persistent storage.
-Examples for different storage providers are available at this link (https://kubernetes.io/docs/concepts/storage/storage-classes/).
+Examples for different storage providers are available at this link (https://kubernetes.io/docs/concepts/storage/storage-classes/).  
 A StorageClass Provisioner might have its own [prerequisites](#storageclass-prereq).
 
 In the Weathervane config file, there are multiple *StorageClass* parameters that should be updated with names defined on your cluster.
@@ -330,7 +330,7 @@ Here are some time estimates for loading a single application instance:
 - A small2 configuration with 16,000 users takes about 50 minutes.
 
 ##### StorageClass Provisioner Prerequisites<a name="storageclass-prereq"></a>
-Ensure that all prerequisites are met for your chosen StorageClass Provisioner.
+Ensure that all prerequisites are met for your chosen StorageClass Provisioner.  
 For example, when using vSphere Storage for Kubernetes, details are available at this link (https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/prerequisites.html).
 
 ##### Cleaning Up Persistent Storage<a name="cleaning-up-persistent-storage"></a>

--- a/doc/userDocs/usersGuide.md
+++ b/doc/userDocs/usersGuide.md
@@ -94,7 +94,7 @@ Weathervane requires at least one existing Kubernetes cluster and a client syste
 - Kubernetes cluster:
     - You must have a kubeconfig file with [credentials](#credentials) for the cluster.
     - There must be at least one [StorageClass](#storageclass) defined on the cluster.
-        - A StorageClass Provisioner might have its own [prerequisites](#storageclass-prereq).
+        - A StorageClass Provisioner might have prerequisites and configuration [steps](#storageclass-prereq).
 - Client system:
     - Configure a workstation (MacOS or Linux) or a Linux VM with the required software:
         - Perl 5 (https://www.perl.org/get.html)
@@ -316,7 +316,7 @@ and auction attendance.
 
 There must be at least one [StorageClass](#storageclass) defined on the application cluster to be used for this persistent storage.
 Examples for different storage providers are available at this link (https://kubernetes.io/docs/concepts/storage/storage-classes/).  
-A StorageClass Provisioner might have its own [prerequisites](#storageclass-prereq).
+A StorageClass Provisioner might have prerequisites and configuration [steps](#storageclass-prereq).
 
 In the Weathervane config file, there are multiple *StorageClass* parameters that should be updated with names defined on your cluster.
 All services may use the same StorageClass, or you can use a different StorageClass for each service.
@@ -330,9 +330,9 @@ Here are some time estimates for loading a single application instance:
 - An xsmall configuration with 12,000 users takes about 30 minutes.
 - A small2 configuration with 16,000 users takes about 50 minutes.
 
-##### StorageClass Provisioner Prerequisites<a name="storageclass-prereq"></a>
-Ensure that all prerequisites are met for your chosen StorageClass Provisioner.  
-For example, when using vSphere Storage for Kubernetes, details are available at this link (https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/prerequisites.html).
+##### StorageClass Provisioner Prerequisites and Configuration<a name="storageclass-prereq"></a>
+Ensure that all prerequisites and configuration steps are completed for your chosen StorageClass Provisioner.  
+For example, when using vSphere Storage for Kubernetes, details are available at this link (https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/).
 
 ##### Cleaning Up Persistent Storage<a name="cleaning-up-persistent-storage"></a>
 

--- a/doc/userDocs/usersGuide.md
+++ b/doc/userDocs/usersGuide.md
@@ -94,6 +94,7 @@ Weathervane requires at least one existing Kubernetes cluster and a client syste
 - Kubernetes cluster:
     - You must have a kubeconfig file with [credentials](#credentials) for the cluster.
     - There must be at least one [StorageClass](#storageclass) defined on the cluster.
+        - A StorageClass Provisioner might have its own [prerequisites](#storageclass-prereq).
 - Client system:
     - Configure a workstation (MacOS or Linux) or a Linux VM with the required software:
         - Perl 5 (https://www.perl.org/get.html)
@@ -314,6 +315,7 @@ and auction attendance.
 
 There must be at least one [StorageClass](#storageclass) defined on the application cluster to be used for this persistent storage.
 Examples for different storage providers are available at this link (https://kubernetes.io/docs/concepts/storage/storage-classes/).
+A StorageClass Provisioner might have its own [prerequisites](#storageclass-prereq).
 
 In the Weathervane config file, there are multiple *StorageClass* parameters that should be updated with names defined on your cluster.
 All services may use the same StorageClass, or you can use a different StorageClass for each service.
@@ -326,6 +328,10 @@ Here are some time estimates for loading a single application instance:
 - A micro configuration with 3,000 users takes about 15 minutes.
 - An xsmall configuration with 12,000 users takes about 30 minutes.
 - A small2 configuration with 16,000 users takes about 50 minutes.
+
+##### StorageClass Provisioner Prerequisites<a name="storageclass-prereq"></a>
+Ensure that all prerequisites are met for your chosen StorageClass Provisioner.
+For example, when using vSphere Storage for Kubernetes, details are available at this link (https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/prerequisites.html).
 
 ##### Cleaning Up Persistent Storage<a name="cleaning-up-persistent-storage"></a>
 
@@ -727,9 +733,9 @@ This section discusses the different configuration file parameters. See [Using W
 ### JSON Primer<a name="JSONprimer"></a>
 
 The Weathervane configuration file uses an extended JSON format.  Quoting from
-the json.org web site: “JSON (JavaScript Object Notation) is a lightweight
+the json.org web site: "JSON (JavaScript Object Notation) is a lightweight
 data-interchange format. It is easy for humans to read and write. It is easy for
-machines to parse and generate.”
+machines to parse and generate."
 
 The basic construct in JSON is a JSON object, which is represented as a set of
 key-value pairs enclosed in curly braces.  The entire Weathervane configuration
@@ -955,7 +961,7 @@ The `description` parameter lets you save a description of the run in its `weath
 
 | Configuration Parameter: description  |
 | ------------------------------------- |
-| `“description” : “Initial Test Run”,` |
+| `"description" : "Initial Test Run",` |
 
 where `Initial Test Run` is any string you specify. 
 

--- a/doc/userDocs/usersGuide.md
+++ b/doc/userDocs/usersGuide.md
@@ -98,6 +98,7 @@ Weathervane requires at least one existing Kubernetes cluster and a client syste
 - Client system:
     - Configure a workstation (MacOS or Linux) or a Linux VM with the required software:
         - Perl 5 (https://www.perl.org/get.html)
+        	- The module for Term::ReadKey should be installed.
         - Docker Engine (https://docs.docker.com/install/)
         - Git (https://git-scm.com/downloads)
         - The `unzip` utility


### PR DESCRIPTION
-In prerequisites, for StorageClass, add text to communicate/clarify that a Provisioner might have a number of required steps that need to be completed before running Weathervane. And, use vSphere Cloud Provider as an example with link.
-In prerequisites, for Perl, note that module Term::ReadKey is required.
-Adjust some quote characters for consistency.
