### PR TITLE
fix errors in pl scripts that prevent running with docker

### DIFF
--- a/runHarness/AppInstance/AuctionAppInstance.pm
+++ b/runHarness/AppInstance/AuctionAppInstance.pm
@@ -240,12 +240,7 @@ override 'checkConfig' => sub {
 		}
 		if ($dbServer->getParamValue('postgresqlUseNamedVolumes') || $host->getParamValue('vicHost')) {
 			# use named volumes.  Error if does not exist
-			my $volumeName = $dbServer->getParamValue('postgresqlDataVolume');
-			if (!$host->dockerVolumeExists($volumeName)) {
-				$console_logger->error("Workload $workloadNum, AppInstance $appInstanceNum: The named volume $volumeName does not exist on Docker host " . $host->name);
-				return 0;
-			}
-			$volumeName = $dbServer->getParamValue('postgresqlLogVolume');
+			my $volumeName = $dbServer->getParamValue('postgresqlVolume');
 			if (!$host->dockerVolumeExists($volumeName)) {
 				$console_logger->error("Workload $workloadNum, AppInstance $appInstanceNum: The named volume $volumeName does not exist on Docker host " . $host->name);
 				return 0;

--- a/runHarness/DataManagers/AuctionDataManager.pm
+++ b/runHarness/DataManagers/AuctionDataManager.pm
@@ -59,7 +59,7 @@ sub startDataManagerContainer {
 	$envVarMap{"MAXUSERS"} = $self->getParamValue('maxUsers');	
 	$envVarMap{"WORKLOADNUM"} = $workloadNum;	
 	$envVarMap{"APPINSTANCENUM"} = $appInstanceNum;	
-	$envVarMap{"JVMOPTS"} = $jvmopts;	
+	$envVarMap{"JVMOPTS"} = "\"$jvmopts\"";
 	$envVarMap{"LOADERTHREADS"} = $loaderThreads;	
 	$envVarMap{"PREPTHREADS"} = $prepThreads;	
 	

--- a/runHarness/Services/CassandraKubernetesService.pm
+++ b/runHarness/Services/CassandraKubernetesService.pm
@@ -178,7 +178,7 @@ sub configure {
 	close FILEIN;
 	close FILEOUT;
 	
-	# Delete the pvcs for postgresqlDataVolume  and postregresqlLogVolume
+	# Delete the pvcs for cassandra
 	# if the size doesn't match the requested size.  
 	# This is to make sure that we are running the
 	# correct configuration size

--- a/runHarness/Services/PostgresqlKubernetesService.pm
+++ b/runHarness/Services/PostgresqlKubernetesService.pm
@@ -192,7 +192,7 @@ sub configure {
 	close FILEIN;
 	close FILEOUT;
 	
-	# Delete the pvcs for postgresqlDataVolume  and postregresqlLogVolume
+	# Delete the pvcs for postgresql
 	# if the size doesn't match the requested size.  
 	# This is to make sure that we are running the
 	# correct configuration size


### PR DESCRIPTION
-There were some leftovers for when postgresql used two volumes.
-And a syntax issue for jvmopts that needs quotes to wrap complicated text.
-also fix a couple of comments for accuracy.