### PR TITLE
Fix Interval Run Strategy

### DIFF
--- a/auctionApp/src/main/java/com/vmware/weathervane/auction/data/imageStore/ImageStoreFacadeCassandraImpl.java
+++ b/auctionApp/src/main/java/com/vmware/weathervane/auction/data/imageStore/ImageStoreFacadeCassandraImpl.java
@@ -255,11 +255,12 @@ public class ImageStoreFacadeCassandraImpl extends ImageStoreFacadeBaseImpl {
 	public byte[] retrieveImage(UUID imageHandle, ImageSize size) throws NoSuchImageException,
 			IOException {
 		logger.info("retrieveImage imageHandle = " + imageHandle + ", imageSize = " + size);
-		List<ImageThumbnail> thumbs = imageThumbnailRepository.findByKeyImageId(imageHandle);
-		List<ImagePreview> previews = imagePreviewRepository.findByKeyImageId(imageHandle);
-		List<ImageFull> fulls = imageFullRepository.findByKeyImageId(imageHandle);
+		List<ImageThumbnail> thumbs;
+		List<ImagePreview> previews;
+		List<ImageFull> fulls;
 		switch (size) {
 		case THUMBNAIL:
+			thumbs = imageThumbnailRepository.findByKeyImageId(imageHandle);
 			if ((thumbs == null) || (thumbs.size() <= 0)) {
 				logger.warn("retrieveImage thumbs = null, imageHandle = " + imageHandle
 						+ ", imageSize = " + size);
@@ -268,6 +269,7 @@ public class ImageStoreFacadeCassandraImpl extends ImageStoreFacadeBaseImpl {
 			return thumbs.get(0).getImage().array();
 
 		case PREVIEW:
+			previews = imagePreviewRepository.findByKeyImageId(imageHandle);
 			if ((previews == null) || (previews.size() <= 0)) {
 				logger.warn("retrieveImage previews = null, imageHandle = " + imageHandle
 						+ ", imageSize = " + size);
@@ -276,10 +278,13 @@ public class ImageStoreFacadeCassandraImpl extends ImageStoreFacadeBaseImpl {
 			return previews.get(0).getImage().array();
 
 		default:
+			fulls = imageFullRepository.findByKeyImageId(imageHandle);
 			if ((fulls == null) || (fulls.size() <= 0)) {
 				// Some items don't have full images, so we send PREVIEW size instead
+				previews = imagePreviewRepository.findByKeyImageId(imageHandle);
 				if ((previews == null) || (previews.size() <= 0)) {
 					// Some items don't have preview images, so we send THUMBNAIL size instead
+					thumbs = imageThumbnailRepository.findByKeyImageId(imageHandle);
 					if ((thumbs == null) || (thumbs.size() <= 0)) {
 						logger.warn("retrieveImage " + size + 
 								" = null, imageHandle = " + imageHandle + ", imageSize = " + size);

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -1318,7 +1318,10 @@ sub startRun {
 								my $endUsersStr = $statsSummary->{"endActiveUsers"};
 								my $numRtOps = $statsSummary->{"totalNumRTOps"};
 								my $numFailedRt = $statsSummary->{"totalNumFailedRT"};
-								my $pctFailRTStr = sprintf("%.2f", 100 * ((1.0 * $numFailedRt) / $numRtOps));
+								my $pctFailRTStr = 0;
+								if ($numRtOps > 0) {
+									$pctFailRTStr = sprintf("%.2f", 100 * ((1.0 * $numFailedRt) / $numRtOps));
+								}
 
 								my $successStr;
 								if ($statsSummary->{"intervalPassed"}) {

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -286,7 +286,7 @@ sub printLoadInterval {
 	my $interval = {};
 
 	$interval->{"duration"} = $loadIntervalRef->{"duration"};
-	$interval->{"name"}     = "$nextIntervalNumber";
+	$interval->{"name"}     = "Interval-$nextIntervalNumber";
 
 	if (   ( exists $loadIntervalRef->{"users"} )
 		&& ( exists $loadIntervalRef->{"duration"} ) )
@@ -1314,6 +1314,12 @@ sub startRun {
 							if (!($endIntervalName =~ /InitialRamp\-(\d+)/)) {
 								my $tptStr = sprintf("%.2f", $statsSummary->{"throughput"});
 								my $rtStr = sprintf("%.2f", $statsSummary->{"avgRT"});
+								my $startUsersStr = $statsSummary->{"startActiveUsers"};
+								my $endUsersStr = $statsSummary->{"endActiveUsers"};
+								my $numRtOps = $statsSummary->{"totalNumRTOps"};
+								my $numFailedRt = $statsSummary->{"totalNumFailedRT"};
+								my $pctFailRTStr = sprintf("%.2f", 100 * ((1.0 * $numFailedRt) / $numRtOps));
+
 								my $successStr;
 								if ($statsSummary->{"intervalPassed"}) {
 									$successStr = 'passed';
@@ -1330,7 +1336,12 @@ sub startRun {
 									}
 									chop($successStr);
 								}
-								my $metricsStr = ", $successStr, throughput:$tptStr, avgRT:$rtStr";
+								my $metricsStr;
+								if ($usingIntervalLoadPathType) {
+									$metricsStr = ", Start Users: $startUsersStr, End Users: $endUsersStr, avgRT:$rtStr, percentFailRT: $pctFailRTStr\%";
+								} else {
+									$metricsStr = ", $successStr, throughput:$tptStr, avgRT:$rtStr";									
+								}
 								$console_logger->info("   [workload $workloadNum, appInstance: $appInstanceNum] Ended: $nameStr${metricsStr}.");
 							}
 						}

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -1163,6 +1163,7 @@ sub startRun {
 	my $usingFindMaxLoadPathType = 0;
 	my $usingSyncedFindMaxLoadPathType = 0;
 	my $usingFixedLoadPathType = 0;
+	my $usingIntervalLoadPathType = 0;
 	my $appInstancesRef = $self->workload->appInstancesRef;
 	foreach my $appInstance (@$appInstancesRef) {
 		my $loadPathType = $appInstance->getParamValue('loadPathType');
@@ -1176,6 +1177,10 @@ sub startRun {
 		}
 		if ($loadPathType eq "fixed" ) {
 			$usingFixedLoadPathType = 1;
+			last;
+		}
+		if ($loadPathType eq "interval" ) {
+			$usingIntervalLoadPathType = 1;
 			last;
 		}
 	}
@@ -1275,7 +1280,7 @@ sub startRun {
 					$logger->debug("$wkldName: curInterval = $curIntervalName");
 				}
 				
-				if ($usingFindMaxLoadPathType || 
+				if ($usingFindMaxLoadPathType ||  $usingIntervalLoadPathType ||
 						$usingSyncedFindMaxLoadPathType || $usingFixedLoadPathType) {
 					$wkldName =~ /appInstance(\d+)/;
 					my $appInstanceNum = $1;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/FixedLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/FixedLoadPath.java
@@ -35,7 +35,7 @@ public class FixedLoadPath extends LoadPath {
 	private boolean exitOnFirstFailure = false;
 	
 	private long timeStep = 10L;
-	
+
 	/*
 	 * Phases in a findMax run: 
 	 * - RAMPUP: Ramp up to users in timeStep intervals

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/IntervalLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/IntervalLoadPath.java
@@ -26,7 +26,7 @@ import com.vmware.weathervane.workloadDriver.common.statistics.StatsSummaryRollu
 public class IntervalLoadPath extends LoadPath {
 	private static final Logger logger = LoggerFactory.getLogger(IntervalLoadPath.class);
 	
-	private List<LoadInterval> loadIntervals = new ArrayList<LoadInterval>();
+	private List<LoadInterval> loadIntervals;
 	
 	@JsonIgnore
 	private List<UniformLoadInterval> uniformIntervals = null;
@@ -265,8 +265,9 @@ public class IntervalLoadPath extends LoadPath {
 	}
 
 	@Override
+	@JsonIgnore
 	public RampLoadInterval getCurStatusInterval() {
-		return getCurStatusInterval();
+		return curStatusInterval;
 	}
 
 	public final List<LoadInterval> getLoadIntervals() {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -123,6 +123,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 		this.statsHostName = statsHostName;
 		this.portNumber = portNumber;
 		this.restTemplate = restTemplate;
+		this.curStatusInterval = new RampLoadInterval();
 	}
 
 	public void start() {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -123,7 +123,6 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 		this.statsHostName = statsHostName;
 		this.portNumber = portNumber;
 		this.restTemplate = restTemplate;
-		this.setCurStatusInterval(new RampLoadInterval());
 	}
 
 	public void start() {

--- a/workloadDriver/src/main/resources/logback.xml
+++ b/workloadDriver/src/main/resources/logback.xml
@@ -15,6 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause
 
     <logger name="com.vmware" level="WARN" />
     <logger name="com.vmware.weathervane.workloadDriver.common.http" level="WARN" />
+    <logger name="com.vmware.weathervane.workloadDriver.common.statistics" level="WARN" />
     <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl" level="WARN" />
     <logger name="com.vmware.weathervane.workloadDriver.common.core.User" level="WARN" />
 


### PR DESCRIPTION
Changes in this pull request:
- The Interval Run Strategy, which allows varying loads, had not been updated properly for changes from Weathervane 1.0 to 2.0 and did not work properly.  The changes in this pull request fix the interval load path so that it works as in Weathervane 1.0.  Note that this pull request does not update the documentation, so this is still an undocumented and unsupported feature.  The documentation will be updated for the next release once we do more testing with this feature.
- Fixed a bug in the Auction application that resulted in an exception when trying to retrieve a full-sized image for non-current items that do not have full images loaded.