### PR TITLE
Check provisioning of PVs in storage classes

### DIFF
--- a/runWeathervane.pl
+++ b/runWeathervane.pl
@@ -438,7 +438,6 @@ my $clusterNameToKubeconfigRef = $retRef->[2];
 my $clusterToStorageClassNamesRef = $retRef->[3];
 
 checkStorageClasses($clusterNameToKubeconfigRef, $clusterToStorageClassNamesRef);
-exit 0;
 
 my $k8sConfigMountString = "";
 foreach my $k8sConfig (@$k8sConfigFilesRef) {

--- a/runWeathervane.pl
+++ b/runWeathervane.pl
@@ -112,15 +112,21 @@ sub parseConfigFile {
 	my %topLevelStorageClassNames;
 	# Parsing the config file manually to avoid requiring the JSON package
 	while (<$configFile>) {		
-		if ($_ =~ /^\s*"kubernetesClusters"\s*\:\s*\[/) {
+		if ($_ =~ /^\s*#/) {
+				next;
+		} elsif ($_ =~ /^\s*"kubernetesClusters"\s*\:\s*\[/) {
 			# Fill out a hash with clustername -> [kubeconfig, context])
 			while (<$configFile>) {	
-				if ($_ =~ /^\s*{/) {
+				if ($_ =~ /^\s*#/) {
+					next;
+				} elsif ($_ =~ /^\s*{/) {
 					my $name = "";
 					my $kubeconfigFileName = "~/.kube/config";
 					my $kubeconfigContext = "";
 					while (<$configFile>) {	
-						if ($_ =~ /^\s*"kubeconfigFile"\s*\:\s*"(.*)"\s*,/) {
+						if ($_ =~ /^\s*#/) {
+							next;
+						} elsif ($_ =~ /^\s*"kubeconfigFile"\s*\:\s*"(.*)"\s*,/) {
 							$kubeconfigFileName = $1;
 							if ((! -e $kubeconfigFileName) || (! -f $kubeconfigFileName)) {
 								print "The kubeconfigFile $kubeconfigFileName must exist and be a regular file.\n";
@@ -147,7 +153,9 @@ sub parseConfigFile {
 			# Don't parse inside workloads 
 			my $numOpenBrackets = 1;
 			while (<$configFile>) {	
-				if ($_ =~ /\[/) {
+				if ($_ =~ /^\s*#/) {
+					next;
+				} elsif ($_ =~ /\[/) {
 					$numOpenBrackets++;
 				} elsif ($_ =~ /\]/) {
 					$numOpenBrackets--;
@@ -160,7 +168,9 @@ sub parseConfigFile {
 			# Don't parse inside appInstances
 			my $numOpenBrackets = 1;
 			while (<$configFile>) {	
-				if ($_ =~ /\[/) {
+				if ($_ =~ /^\s*#/) {
+					next;
+				} elsif ($_ =~ /\[/) {
 					$numOpenBrackets++;
 				} elsif ($_ =~ /\]/) {
 					$numOpenBrackets--;

--- a/runWeathervane.pl
+++ b/runWeathervane.pl
@@ -18,6 +18,7 @@ my $outputDir = 'output';
 my $tmpDir = '';
 my $backgroundScript = '';
 my $mapSsh = '';
+my $skipPvTest = '';
 my $fixedConfigsFile = "";
 my $scriptPeriodSec = 60;
 my $help = '';
@@ -37,6 +38,7 @@ GetOptions(	'accept!' => \$accept,
 			'fixedConfigsFile=s' => \$fixedConfigsFile,
 			'scriptPeriod=i' => \$scriptPeriodSec,
 			'mapSsh!' => \$mapSsh,
+			'skipPvTest!' => \$skipPvTest,
 			'help!' => \$help,
 		);
 		
@@ -87,6 +89,9 @@ sub usage {
 	print "              from another script.  Only needs to be specified on the first run in a given directory.\n";
 	print "              default value: None.  If no value is specified the user is prompted to accept the\n";
 	print "                             license terms.\n";
+	print "--skipPvTest: Causes the scipt to skip testing whether Weathervane can dynamically allocate \n";
+	print "              persistant volumes in the storage classes defined in the configuration file.\n";
+	print "              default value: False";
 	print "--help:       Displays this text.\n";
 	print "\n";
 	print "To pass command-line parameters to the Weathervane run harness, enter them following two dashes\n";
@@ -437,7 +442,9 @@ my $dockerNamespace = $retRef->[1];
 my $clusterNameToKubeconfigRef = $retRef->[2];
 my $clusterToStorageClassNamesRef = $retRef->[3];
 
-checkStorageClasses($clusterNameToKubeconfigRef, $clusterToStorageClassNamesRef);
+if (!$skipPvTest) {
+	checkStorageClasses($clusterNameToKubeconfigRef, $clusterToStorageClassNamesRef);
+}
 
 my $k8sConfigMountString = "";
 foreach my $k8sConfig (@$k8sConfigFilesRef) {


### PR DESCRIPTION
Changes in this pull request:
- Added a check in runWeathervane.pl to make sure that Weathervane can dynamically provision persistent volumes using a PVC for all storage classes.  Note that this check only works for the simple case of the applicationInstanceCluster and storageClasses being defined at the top level (not inside workloads and appInstances).  The more complex cases will be handled later inside the run harness.