### PR TITLE
Ensure Datamanager pod is stopped before starting other pods

### DIFF
--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -141,6 +141,11 @@ sub stopDataManagerContainer {
 	$cluster->kubernetesDelete("configMap", "auctiondatamanager-config", $self->appInstance->namespace);
 	$cluster->kubernetesDelete("deployment", "auctiondatamanager", $self->appInstance->namespace);
 
+	# Don't return until the data manager pod has terminated
+    my $podExists = 1;
+    do {
+	  $podExists = $self->host->kubernetesDoPodsExist("impl=auctiondatamanager", $self->appInstance->namespace );    	
+    } while ($podExists);
 }
 
 sub prepareDataServices {


### PR DESCRIPTION
The AuctionDataManager pod takes a large amount of resources (CPU and memory) relative to other pods.  Currently the prepareData process can return before this pod has terminated. This can keep other pods from starting, leading to misleading failedScheduling errors.

The fix is to wait until the pod has terminated before returning.

Signed-off-by: Hal Rosenberg <hrosenbe@vmware.com>