### PR TITLE
Add auto flushing to runWeathervane.pl

### DIFF
--- a/runWeathervane.pl
+++ b/runWeathervane.pl
@@ -23,6 +23,9 @@ my $fixedConfigsFile = "";
 my $scriptPeriodSec = 60;
 my $help = '';
 
+# Turn on auto flushing of output
+BEGIN { $| = 1 }
+
 if ((-e "./version.txt") && (-f "./version.txt")) {
   $version = `cat ./version.txt`;
   chomp($version);	


### PR DESCRIPTION
Under certain conditions, the output coming from a container doesn't appear in real time in the console. Only after the run completes will the output be displayed.
Previous to this fix: 
![image-2020-07-24-15-46-17-656](https://user-images.githubusercontent.com/22941180/89068043-160f0800-d336-11ea-894e-87c9b8068f16.png)
@bhoflich suggested to add auto flushing to runWeathervane.pl like already exists in weathervane.pl. This resolves the issue.
With this fix:
![image](https://user-images.githubusercontent.com/22941180/89068109-33dc6d00-d336-11ea-9e66-7b777e57bf52.png)
Signed-off-by: Rebecca Yo <griderr@vmware.com>