### PR TITLE
Add parameter to control whether kubectl top is collected

### DIFF
--- a/configFiles/esxtop/wv.esxtoprc
+++ b/configFiles/esxtop/wv.esxtoprc
@@ -1,4 +1,4 @@
-ABcDEFghij
+ABcDEFgHij
 aBcDefGHijklmnOpq
 AbcDEfgHIjkl
 AbcdeFGhiJKLmnop

--- a/runHarness/ComputeResources/KubernetesCluster.pm
+++ b/runHarness/ComputeResources/KubernetesCluster.pm
@@ -1429,17 +1429,18 @@ override 'startStatsCollection' => sub {
 	my ( $self, $intervalLengthSec, $numIntervals, $tmpDir ) = @_;
 	my $logger         = get_logger("Weathervane::Clusters::KubernetesCluster");
 
-	my $destinationDir = "$tmpDir/statistics/kubernetes";
-	my $cmd;
-	$cmd = "mkdir -p $destinationDir";
-	my ($cmdFailed, $outString) = runCmd($cmd);
-	if ($cmdFailed) {
-		$logger->error("startStatsCollection failed: $cmdFailed");
-		return;
-	}
+	if ($self->getParamValue('collectKubectlTop')) {
+		my $destinationDir = "$tmpDir/statistics/kubernetes";
+		my $cmd = "mkdir -p $destinationDir";
+		my ($cmdFailed, $outString) = runCmd($cmd);
+		if ($cmdFailed) {
+			$logger->error("startStatsCollection failed: $cmdFailed");
+			return;
+		}
 
-	$self->kubernetesTopPodAllNamespaces(15, $destinationDir);
-	$self->kubernetesTopNode(15, $destinationDir);
+		$self->kubernetesTopPodAllNamespaces(15, $destinationDir);
+		$self->kubernetesTopNode(15, $destinationDir);
+	}
 };
 
 override 'stopStatsCollection' => sub {

--- a/runHarness/Parameters.pm
+++ b/runHarness/Parameters.pm
@@ -576,6 +576,13 @@ $parameters{"kubeconfigContext"} = {
 	"usageText" => "This is the context to use from within the kubeconfig file.",
 	"showUsage" => 1,
 };
+$parameters{"collectKubectlTop"} = {
+	"type"      => "!",
+	"default"   => JSON::false,
+	"parent"    => "kubernetesCluster",
+	"usageText" => "If set to true, Weathervane will not attempt collect kubectl top data.",
+	"showUsage" => 1,
+};
 $parameters{"createNamespaces"} = {
 	"type"      => "!",
 	"default"   => JSON::true,


### PR DESCRIPTION
Changes in this pull request:
- Added a parameter that controls whether `kubectl top` data is collected.  This defaults to false since most clusters don't support this by default. 
