### PR TITLE
Don't exit when pod not found in kubernetesExecOne

### DIFF
--- a/runHarness/ComputeResources/KubernetesCluster.pm
+++ b/runHarness/ComputeResources/KubernetesCluster.pm
@@ -579,23 +579,23 @@ sub kubernetesExecOne {
 	$logger->debug("Output: $outString");
 	my @names = split /\s+/, $outString;
 	if ($#names < 0) {
-		$console_logger->error("kubernetesExecOne: There are no pods with label $serviceTypeImpl in namespace $namespace");
-		exit(-1);
+		$console_logger->debug("kubernetesExecOne: There are no pods with label $serviceTypeImpl in namespace $namespace");
+		$cmdFailed = 1;
+		$outString = "";		
+	} else {	
+		# Get the name of the first pod
+		my $podName = $names[0];
+	
+		$cmd = "kubectl exec -c $serviceTypeImpl --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString $podName -- $commandString";
+		($cmdFailed, $outString) = runCmd($cmd);
+		if ($cmdFailed) {
+			$logger->info("kubernetesExecOne exec failed: $cmdFailed");
+		}
+		$logger->debug("Command: $cmd");
+		$logger->debug("Output: $outString");
 	}
-	
-	# Get the name of the first pod
-	my $podName = $names[0];
-	
-	$cmd = "kubectl exec -c $serviceTypeImpl --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString $podName -- $commandString";
-	($cmdFailed, $outString) = runCmd($cmd);
-	if ($cmdFailed) {
-		$logger->info("kubernetesExecOne exec failed: $cmdFailed");
-	}
-	$logger->debug("Command: $cmd");
-	$logger->debug("Output: $outString");
-	
+
 	return ($cmdFailed, $outString);
-	
 }
 
 # Does a kubectl exec in all p[ods] where the impl label matches  


### PR DESCRIPTION
Changes in this pull request:
- Previously, when no pod with the appropriate label was found in the method kubernetesExecOne, the process would exit.  This prevented the caller from retrying.  I changed this to return with an error rather than exiting.  I check all of the callers, and they can all handle the error return correctly.

Signed-off-by: Hal Rosenberg <hrosenbe@vmware.com>