### PR TITLE
handle harbor robot names

### DIFF
--- a/buildDockerImages.pl
+++ b/buildDockerImages.pl
@@ -292,7 +292,7 @@ if (!$private || $username) {
 
 	print "Logging into $hostString\n";
 	print $fileout "Logging into $hostString\n";
-	my $cmd = "docker login -u=$username -p=$password $host";
+	my $cmd = "docker login -u=\'$username\' -p=$password $host";
 	my $response = `$cmd 2>&1`;
 	print $fileout "result: $response\n";
 	if ($response =~ /unauthorized/) {

--- a/doc/userDocs/usersGuide.md
+++ b/doc/userDocs/usersGuide.md
@@ -402,6 +402,8 @@ The process using a private repository is as follows:
         * `./buildDockerImages.pl --private --host hostname --port 5001 --username yourUserName`
         * The script will prompt for password.
 
+If yourUserName contains special characters, such as the $ sign, wrap yourUserName in single quotes so it is passed as intended to the script.
+
 The process to build and push the images can take as long as an hour to complete.
 
 ## Using Weathervane<a name="using"></a>


### PR DESCRIPTION
wrap docker login username in single quotes to allow special characters
and add line to documentation for : wrap yourUserName in single quotes
Signed-off-by: Benjamin Hoflich <45051453+bhoflich@users.noreply.github.com>