### PR TITLE
Rebeccayo/archive build docker images log

### DIFF
--- a/testing/Jenkinsfile
+++ b/testing/Jenkinsfile
@@ -28,12 +28,14 @@ node('wvtest-AuctionDriver') {
                 // Build executables and images, push to Harbor
 				sh label: '', script: 'printf \'$ROBOT_PASSWORD\' | ./buildDockerImages.pl --private --host \'harbor-repo.vmware.com/weathervaneci\' --username $ROBOT_USERNAME'
             }
+			archiveArtifacts 'buildDockerImages.log'
  }
         stage('test') {
             sh label: '', script: 'python3 testing/e2e/runE2eTests.py'
         }
         return
     } catch (err) {
+		archiveArtifacts 'buildDockerImages.log'
         notify("Error: ${err}")
         currentBuild.result = 'FAILURE'
     }

--- a/testing/Jenkinsfile
+++ b/testing/Jenkinsfile
@@ -28,17 +28,17 @@ node('wvtest-AuctionDriver') {
                 // Build executables and images, push to Harbor
 				sh label: '', script: 'printf \'$ROBOT_PASSWORD\' | ./buildDockerImages.pl --private --host \'harbor-repo.vmware.com/weathervaneci\' --username $ROBOT_USERNAME'
             }
-			archiveArtifacts 'buildDockerImages.log'
- }
+		}
         stage('test') {
             sh label: '', script: 'python3 testing/e2e/runE2eTests.py'
         }
         return
     } catch (err) {
-		archiveArtifacts 'buildDockerImages.log'
         notify("Error: ${err}")
         currentBuild.result = 'FAILURE'
-    }
+    } finally {
+		archiveArtifacts 'buildDockerImages.log'
+	}
 }
 
 def notify(status){


### PR DESCRIPTION
Add archive step which follows all builds, failed or not. 
Groovy 'archiveArtifacts' causes Jenkins to save the named file which then be viewed in Jenkins along with the build info.
More files will be archived as needed.