### PR TITLE
Parallize workload driver inter-node communication

### DIFF
--- a/dockerImages/auctiondatamanager/loadData.pl
+++ b/dockerImages/auctiondatamanager/loadData.pl
@@ -46,10 +46,16 @@ my $dbLoaderClasspath = "/dbLoader.jar:/dbLoaderLibs/*:/dbLoaderLibs";
 my $cmdString = "java $jvmopts $dbLoaderJavaOptions -Dwkld=W${workloadNum}I${appInstanceNum}" .
 				" -cp $dbLoaderClasspath -Dspring.profiles.active=\"$springProfilesActive\"" .
 				" -DDBHOSTNAME=$dbHostname -DDBPORT=$dbPort -DCASSANDRA_CONTACTPOINTS=$cassandraContactpoints" . 
-				" -DCASSANDRA_PORT=$cassandraPort com.vmware.weathervane.auction.dbloader.DBLoader $dbLoaderOptions 2>/dev/null";
+				" -DCASSANDRA_PORT=$cassandraPort com.vmware.weathervane.auction.dbloader.DBLoader $dbLoaderOptions";
 				
-print "Running for appInstance $appInstanceNum: $cmdString\n";
-system($cmdString);
+print "Running dbLoader for Workload $workloadNum, appInstance $appInstanceNum: $cmdString\n";
+my $exitCode = system($cmdString);
+
+if ($exitCode) {
+	$exitCode = $exitCode >> 8;
+	print "loadData.pl for Workload $workloadNum, appInstance $appInstanceNum: dbLoader exited with exitCode $exitCode, error: $!\n";
+	exit $exitCode;
+}
 
 print "Catting /images/.db*\n";
 `cat /images/.db*`;

--- a/runHarness/ComputeResources/KubernetesCluster.pm
+++ b/runHarness/ComputeResources/KubernetesCluster.pm
@@ -571,7 +571,7 @@ sub kubernetesExecOne {
 	my $outString;
 	my $cmdFailed;
 	$cmd = "kubectl get pod -o=jsonpath='{.items[*].metadata.name}' --selector=impl=$serviceTypeImpl --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString";
-	($cmdFailed, $outString) = runCmd($cmd);
+	($cmdFailed, $outString) = runCmd($cmd, 0);
 	if ($cmdFailed) {
 		$logger->error("kubernetesExecOne get pod failed: $cmdFailed");
 	}
@@ -587,7 +587,7 @@ sub kubernetesExecOne {
 		my $podName = $names[0];
 	
 		$cmd = "kubectl exec -c $serviceTypeImpl --namespace=$namespace --kubeconfig=$kubeconfigFile $contextString $podName -- $commandString";
-		($cmdFailed, $outString) = runCmd($cmd);
+		($cmdFailed, $outString) = runCmd($cmd, 0);
 		if ($cmdFailed) {
 			$logger->info("kubernetesExecOne exec failed: $cmdFailed");
 		}

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -139,40 +139,40 @@ sub stopDataManagerContainer {
 	my $logger         = get_logger("Weathervane::DataManager::AuctionKubernetesDataManager");
 	my $cluster = $self->host;
 	
-	# before deleting the deployment, capture info about state of the datamanage 
+	# before deleting the deployment, capture info about state of the datamanager 
 	# pod and dump it to the log
 	my $namespace = $self->appInstance->namespace;
 	my $kubernetesConfigFile = $cluster->getParamValue('kubeconfigFile');
 	my $context = $cluster->getParamValue('kubeconfigContext');
 	my $contextString = "";
 	if ($context) {
-	  $contextString = "--context=$context";	
+		$contextString = "--context=$context";	
 	}
 	my $cmd = "kubectl describe pod --namespace=$namespace --selector=impl=auctiondatamanager --kubeconfig=$kubernetesConfigFile $contextString";
-    my ($cmdFailed, $outString) = runCmd($cmd);
-    if ($cmdFailed) {
-        $logger->error("stopDataManagerContainer kubernetes describe pod failed: $cmdFailed");
-    }
-    $logger->debug("Command: $cmd");
-    $logger->debug("Output: $outString");
+	my ($cmdFailed, $outString) = runCmd($cmd);
+	if ($cmdFailed) {
+		$logger->error("stopDataManagerContainer kubernetes describe pod failed: $cmdFailed");
+	}
+	$logger->debug("Command: $cmd");
+	$logger->debug("Output: $outString");
 	print $applog "Command: $cmd\n";
 	print $applog "Output: $outString\n";
 	
 	$cluster->kubernetesDelete("configMap", "auctiondatamanager-config", $self->appInstance->namespace);
 	$cluster->kubernetesDelete("deployment", "auctiondatamanager", $self->appInstance->namespace);
-
+	
 	# Don't return until the data manager pod has terminated.  
 	# Give it five minutes total, which is excessive 
 	my $retries = 30;;
 	my $sleepDuration = 10; 
-    my $podExists = 1;
-    do {
-	  $podExists = $self->host->kubernetesDoPodsExist("impl=auctiondatamanager", $self->appInstance->namespace );
-	  if ($podExists) {
-	    $retries--;    	
-	  	sleep $sleepDuration;
-	  }
-    } while ($podExists && ($retries > 0));
+	my $podExists = 1;
+	do {
+		$podExists = $self->host->kubernetesDoPodsExist("impl=auctiondatamanager", $self->appInstance->namespace );
+		if ($podExists) {
+			$retries--;    	
+			sleep $sleepDuration;
+		}
+	} while ($podExists && ($retries > 0));
 	# Even if the pod hasn't terminated yet, we let the run proceed because in most
 	# cases this won't cause a problem 
 }

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -148,17 +148,8 @@ sub stopDataManagerContainer {
 	if ($context) {
 	  $contextString = "--context=$context";	
 	}
-	my $cmd = "kubectl get pod --namespace=$namespace --show-labels --kubeconfig=$kubernetesConfigFile $contextString";
+	my $cmd = "kubectl describe pod --namespace=$namespace --selector=impl=auctiondatamanager --kubeconfig=$kubernetesConfigFile $contextString";
     my ($cmdFailed, $outString) = runCmd($cmd);
-    if ($cmdFailed) {
-        $logger->error("stopDataManagerContainer kubernetes get pod failed: $cmdFailed");
-    }
-    $logger->debug("Command: $cmd");
-    $logger->debug("Output: $outString");
-	print $applog "Command: $cmd\n";
-	print $applog "Output: $outString\n";
-	$cmd = "kubectl describe pod --namespace=$namespace --selector=impl=auctiondatamanager --kubeconfig=$kubernetesConfigFile $contextString";
-    ($cmdFailed, $outString) = runCmd($cmd);
     if ($cmdFailed) {
         $logger->error("stopDataManagerContainer kubernetes describe pod failed: $cmdFailed");
     }

--- a/runHarness/Parameters.pm
+++ b/runHarness/Parameters.pm
@@ -1820,14 +1820,6 @@ $parameters{"driverHttpThreads"} = {
 	"showUsage" => 1,
 };
 
-$parameters{"driverRunPoolMultiplier"} = {
-	"type"      => "=i",
-	"default"   => 0,
-	"parent"    => "workloadDriver",
-	"usageText" => "",
-	"showUsage" => 1,
-};
-
 $parameters{"driverMaxTotalConnectionsMultiplier"} = {
 	"type"      => "=f",
 	"default"   => 2,

--- a/runHarness/Parameters.pm
+++ b/runHarness/Parameters.pm
@@ -2687,6 +2687,14 @@ $parameters{"showPeriodicOutput"} = {
 	"showUsage" => 1,
 };
 
+$parameters{"printStatsCsv"} = {
+	"type"      => "!",
+	"default"   => JSON::false,
+	"parent"    => "workloadDriver",
+	"usageText" => "Controls whether csv files containing detailed stats are printed by the workload controller.",
+	"showUsage" => 1,
+};
+
 $parameters{"fullHelp"} = {
 	"type"      => "!",
 	"default"   => JSON::false,

--- a/runHarness/Parameters.pm
+++ b/runHarness/Parameters.pm
@@ -1067,7 +1067,7 @@ $parameters{"repeatUserLoadPath"} = {
 	"showUsage" => 0,
 };
 
-# Parameters for selecting the runManager
+# Parameter for selecting the runManager
 $parameters{"runStrategy"} = {
 	"type"      => "=s",
 	"default"   => "findMaxSingleRun",
@@ -1089,6 +1089,14 @@ $parameters{"instanceNodeLabels"} = {
 	"default"   => JSON::false,
 	"parent"    => "runManager",
 	"usageText" => "If true, the appInstances will only run on Kubernetes nodes with the appropriate label, e.g. wvauctionw1i1=",
+	"showUsage" => 1,
+};
+
+$parameters{"perTargetStats"} = {
+	"type"      => "!",
+	"default"   => JSON::false,
+	"parent"    => "workload",
+	"usageText" => "If true, the workload driver will collect stats for each target, which adds overhead",
 	"showUsage" => 1,
 };
 

--- a/runHarness/Parameters.pm
+++ b/runHarness/Parameters.pm
@@ -1812,6 +1812,14 @@ $parameters{"driverHttpThreads"} = {
 	"showUsage" => 1,
 };
 
+$parameters{"driverRunPoolMultiplier"} = {
+	"type"      => "=i",
+	"default"   => 0,
+	"parent"    => "workloadDriver",
+	"usageText" => "",
+	"showUsage" => 1,
+};
+
 $parameters{"driverMaxTotalConnectionsMultiplier"} = {
 	"type"      => "=f",
 	"default"   => 2,

--- a/runHarness/RunProcedures/RunProcedure.pm
+++ b/runHarness/RunProcedures/RunProcedure.pm
@@ -466,12 +466,7 @@ sub stopServicesInClusters {
 	my $logger = get_logger("Weathervane::RunProcedures::RunProcedure");
 	$logger->debug("stopServicesInClusters");
 
-	my $clustersRef = $self->clustersRef;
-	foreach my $cluster (@$clustersRef) {
-		my $clusterName = $cluster->name;
-		$logger->debug("stopServicesInClusters for $clusterName");
-		$cluster->kubernetesDeleteAllForCluster();
-	}
+	callMethodOnObjectsParallel( 'kubernetesDeleteAllForCluster', $self->clustersRef );
 }
 
 sub stopDataManager {

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -399,8 +399,7 @@ sub createRunConfigHash {
 	$runRef->{"statsOutputDirName"} = "/tmp";
 	my $driverRunPoolMultiplier = $self->getParamValue('driverRunPoolMultiplier');
 	if (!$driverRunPoolMultiplier) {
-		my $numHosts = $#{$self->getHosts()} +1;
-		$driverRunPoolMultiplier = $numHosts + 2;
+		$driverRunPoolMultiplier = 20;
 	}
 	$runRef->{"threadPoolMultiplier"} = $driverRunPoolMultiplier;
 

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -397,11 +397,6 @@ sub createRunConfigHash {
 	$runRef->{"runStatsHost"}          = $self->getRunStatsHost();
 	$runRef->{"workloadStatsHost"}     = $self->getWorkloadStatsHost();
 	$runRef->{"statsOutputDirName"} = "/tmp";
-	my $driverRunPoolMultiplier = $self->getParamValue('driverRunPoolMultiplier');
-	if (!$driverRunPoolMultiplier) {
-		$driverRunPoolMultiplier = 20;
-	}
-	$runRef->{"threadPoolMultiplier"} = $driverRunPoolMultiplier;
 	$runRef->{"perTargetStats"}     = $self->getParamValue('perTargetStats');
 
 	$runRef->{"workloads"} = [];

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -397,6 +397,12 @@ sub createRunConfigHash {
 	$runRef->{"runStatsHost"}          = $self->getRunStatsHost();
 	$runRef->{"workloadStatsHost"}     = $self->getWorkloadStatsHost();
 	$runRef->{"statsOutputDirName"} = "/tmp";
+	my $driverRunPoolMultiplier = $self->getParamValue('driverRunPoolMultiplier');
+	if (!$driverRunPoolMultiplier) {
+		my $numHosts = $#{$self->getHosts()} +1;
+		$driverRunPoolMultiplier = $numHosts + 2;
+	}
+	$runRef->{"threadPoolMultiplier"} = $driverRunPoolMultiplier;
 
 	$runRef->{"workloads"} = [];
 	

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -402,6 +402,7 @@ sub createRunConfigHash {
 		$driverRunPoolMultiplier = 20;
 	}
 	$runRef->{"threadPoolMultiplier"} = $driverRunPoolMultiplier;
+	$runRef->{"perTargetStats"}     = $self->getParamValue('perTargetStats');
 
 	$runRef->{"workloads"} = [];
 	

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -445,7 +445,7 @@ sub createRunConfigHash {
 		$loadPath->{"isStatsInterval"} = JSON::true;
 		$loadPath->{"printSummary"}    = JSON::true;
 		$loadPath->{"printIntervals"}  = JSON::false;
-		$loadPath->{"printCsv"}        = JSON::true;
+		$loadPath->{"printCsv"}        = $self->getParamValue('printStatsCsv');
 
 		if ( $loadPathType eq "fixed" ) {
 			$logger->debug(
@@ -518,7 +518,7 @@ sub createRunConfigHash {
 		$statsIntervalSpec->{'type'} = "periodic"; 
 		$statsIntervalSpec->{"printSummary"} = JSON::false;
 		$statsIntervalSpec->{"printIntervals"} = JSON::true;
-		$statsIntervalSpec->{"printCsv"}       = JSON::true;
+		$statsIntervalSpec->{"printCsv"}       = $self->getParamValue('printStatsCsv');
 		$statsIntervalSpec->{"period"} = $self->getParamValue('statsInterval');
 		push @$statsIntervalSpecs, $statsIntervalSpec;
 		$workload->{"statsIntervalSpecs"} = $statsIntervalSpecs;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/common/AuctionOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/common/AuctionOperation.java
@@ -24,7 +24,7 @@ import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 import io.netty.handler.codec.http.HttpHeaders;
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/factory/AuctionOperationFactory.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/factory/AuctionOperationFactory.java
@@ -38,7 +38,7 @@ import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.HttpTarget;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
 import com.vmware.weathervane.workloadDriver.common.factory.OperationFactory;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class AuctionOperationFactory implements OperationFactory {
 	private static final Logger logger = LoggerFactory.getLogger(AuctionOperationFactory.class);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/AddAuctionOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/AddAuctionOperation.java
@@ -8,7 +8,7 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionOp
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class AddAuctionOperation extends AuctionOperation  {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/AddImageForItemOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/AddImageForItemOperation.java
@@ -27,7 +27,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
 import com.vmware.weathervane.workloadDriver.common.http.FileUploadInfo;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class AddImageForItemOperation extends AuctionOperation implements NeedsLoginResponse, NeedsAddedItemId {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/AddItemOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/AddItemOperation.java
@@ -20,8 +20,8 @@ import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 import com.vmware.weathervane.workloadDriver.common.core.User;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
 
 public class AddItemOperation extends AuctionOperation implements NeedsLoginResponse, ContainsAddedItemId {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/AddItemToAuctionOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/AddItemToAuctionOperation.java
@@ -6,12 +6,9 @@ package com.vmware.weathervane.workloadDriver.benchmarks.auction.operations;
 
 import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionOperation;
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
-import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
-import com.vmware.weathervane.workloadDriver.common.core.target.Target;
 import com.vmware.weathervane.workloadDriver.common.core.User;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
-
-import io.netty.buffer.ByteBuf;
+import com.vmware.weathervane.workloadDriver.common.core.target.Target;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class AddItemToAuctionOperation extends AuctionOperation  {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetActiveAuctionsOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetActiveAuctionsOperation.java
@@ -25,16 +25,14 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionSt
 import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionStateManagerStructs.NeedsAttendedAuctions;
 import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionStateManagerStructs.NeedsLoginResponse;
 import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionStateManagerStructs.NeedsPageSize;
-import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionStateManagerStructs.NeedsUsersPerAuction;
 import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionStateManagerStructs.PageSizeProvider;
-import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionStateManagerStructs.UsersPerAuctionProvider;
 import com.vmware.weathervane.workloadDriver.benchmarks.auction.representation.AuctionRepresentation;
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
-import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
+import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetActiveAuctionsOperation extends AuctionOperation implements
 		NeedsLoginResponse, NeedsPageSize, NeedsActiveAuctions, ContainsActiveAuctions, 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetAttendanceHistoryOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetAttendanceHistoryOperation.java
@@ -24,7 +24,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetAttendanceHistoryOperation extends AuctionOperation implements NeedsLoginResponse,
 		NeedsPageSize, NeedsAttendanceHistoryInfo, ContainsAttendanceHistoryInfo {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetAuctionDetailOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetAuctionDetailOperation.java
@@ -28,7 +28,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetAuctionDetailOperation extends AuctionOperation implements NeedsLoginResponse, 
 	NeedsActiveAuctions, ContainsAuctionItems, NeedsAuctionItems, NeedsPageSize {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetAuctionsForAuctioneerOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetAuctionsForAuctioneerOperation.java
@@ -8,7 +8,7 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionOp
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetAuctionsForAuctioneerOperation extends AuctionOperation  {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetBidHistoryOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetBidHistoryOperation.java
@@ -24,7 +24,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetBidHistoryOperation extends AuctionOperation implements NeedsLoginResponse,
 		NeedsPageSize, NeedsBidHistoryInfo, ContainsBidHistoryInfo {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetCurrentItemOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetCurrentItemOperation.java
@@ -27,10 +27,10 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionSt
 import com.vmware.weathervane.workloadDriver.benchmarks.auction.representation.AuctionRepresentation;
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
-import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
+import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetCurrentItemOperation extends AuctionOperation implements NeedsLoginResponse, NeedsCurrentAuction,
 		ContainsCurrentItem, ContainsCurrentBid, NeedsCurrentItem {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetImageForItemOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetImageForItemOperation.java
@@ -20,7 +20,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetImageForItemOperation extends AuctionOperation implements NeedsLoginResponse, NeedsDetailItem {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetItemDetailOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetItemDetailOperation.java
@@ -24,7 +24,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetItemDetailOperation extends AuctionOperation implements NeedsLoginResponse, 
 	NeedsAuctionItems, ContainsDetailItem {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetItemsForAuctioneerOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetItemsForAuctioneerOperation.java
@@ -8,7 +8,7 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionOp
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetItemsForAuctioneerOperation extends AuctionOperation  {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetNextBidOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetNextBidOperation.java
@@ -32,9 +32,9 @@ import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.exceptions.OperationFailedException;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
 
 public class GetNextBidOperation extends AuctionOperation implements NeedsLoginResponse, NeedsCurrentAuction, NeedsCurrentItem,
 		NeedsCurrentBid, ContainsCurrentBid, NeedsUserProfile {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetPurchaseHistoryOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetPurchaseHistoryOperation.java
@@ -25,7 +25,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetPurchaseHistoryOperation extends AuctionOperation implements NeedsLoginResponse,
 		NeedsPageSize, ContainsPurchaseHistoryInfo, NeedsPurchaseHistoryInfo {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetUserProfileOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/GetUserProfileOperation.java
@@ -21,7 +21,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class GetUserProfileOperation extends AuctionOperation implements NeedsLoginResponse, 
 	ContainsUserProfile {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/HomePageOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/HomePageOperation.java
@@ -16,7 +16,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class HomePageOperation extends AuctionOperation {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/JoinAuctionOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/JoinAuctionOperation.java
@@ -42,10 +42,10 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionSt
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
-import com.vmware.weathervane.workloadDriver.common.core.target.Target;
 import com.vmware.weathervane.workloadDriver.common.core.User;
+import com.vmware.weathervane.workloadDriver.common.core.target.Target;
 import com.vmware.weathervane.workloadDriver.common.exceptions.OperationFailedException;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class JoinAuctionOperation extends AuctionOperation implements NeedsLoginResponse,
 		ContainsCurrentAuction, ContainsCurrentItem, ContainsCurrentBid, NeedsAttendedAuctions,

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/LeaveAuctionOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/LeaveAuctionOperation.java
@@ -22,7 +22,7 @@ import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class LeaveAuctionOperation extends AuctionOperation implements NeedsLoginResponse, 
 	NeedsAuctionIdToLeave, ContainsAttendedAuctions {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/LoginOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/LoginOperation.java
@@ -7,7 +7,6 @@ package com.vmware.weathervane.workloadDriver.benchmarks.auction.operations;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.omg.CosNaming._BindingIteratorImplBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,10 +24,10 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.strategies.Rando
 import com.vmware.weathervane.workloadDriver.common.chooser.Chooser;
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
-import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
+import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class LoginOperation extends AuctionOperation implements  NeedsPersonNames, NeedsPassword,
 		ChoosesBidStrategy, ContainsLoginResponse {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/LogoutOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/LogoutOperation.java
@@ -17,7 +17,7 @@ import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class LogoutOperation extends AuctionOperation implements NeedsLoginResponse {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/NoOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/NoOperation.java
@@ -8,7 +8,7 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionOp
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class NoOperation extends AuctionOperation  {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/PlaceBidOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/PlaceBidOperation.java
@@ -33,7 +33,7 @@ import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.XHolderProvider;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class PlaceBidOperation extends AuctionOperation implements NeedsLoginResponse, NeedsCurrentAuction, NeedsCurrentItem,
 		NeedsCurrentBid, NeedsUserProfile, NeedsBidStrategy {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/RegisterOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/RegisterOperation.java
@@ -8,7 +8,7 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionOp
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 
 public class RegisterOperation extends AuctionOperation  {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/SearchAuctionsOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/SearchAuctionsOperation.java
@@ -8,7 +8,7 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionOp
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 
 public class SearchAuctionsOperation extends AuctionOperation  {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/SearchItemsOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/SearchItemsOperation.java
@@ -8,7 +8,7 @@ import com.vmware.weathervane.workloadDriver.benchmarks.auction.common.AuctionOp
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public class SearchItemsOperation extends AuctionOperation  {
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/UpdateUserProfileOperation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/benchmarks/auction/operations/UpdateUserProfileOperation.java
@@ -26,7 +26,7 @@ import com.vmware.weathervane.workloadDriver.common.core.SimpleUri;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.StateManagerStructs.DataListener;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 
 public class UpdateUserProfileOperation extends AuctionOperation implements  NeedsLoginResponse, NeedsUserProfile,

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Behavior.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Behavior.java
@@ -25,7 +25,7 @@ import com.vmware.weathervane.workloadDriver.common.core.target.Target;
 import com.vmware.weathervane.workloadDriver.common.http.HttpTransport;
 import com.vmware.weathervane.workloadDriver.common.random.NegativeExponential;
 import com.vmware.weathervane.workloadDriver.common.random.TruncatedNormal;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 /**
  * @author Hal

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Operation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Operation.java
@@ -647,7 +647,14 @@ public abstract class Operation implements Runnable, HttpRequestCompleteCallback
 
 			logger.debug("Submitting operationStats to statsCollector for operation " + getOperationName() + " for behavior UUID "
 						+ _behavior.getBehaviorId() );
-			_statsCollector.submitOperationStats(new OperationStats(this));
+			OperationStats opStats;
+			try {
+				opStats = new OperationStats(this);
+				_statsCollector.submitOperationStats(opStats);
+			} catch (Exception e) {
+				logger.warn("Operation:run caught exception when creating opStats: {}, {}",
+						e.getCause(), e.getMessage());
+			}
 			
 			/*
 			 * If the operation has failed, then we need to reset the user and restart 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Operation.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Operation.java
@@ -34,7 +34,7 @@ import com.vmware.weathervane.workloadDriver.common.http.FileUploadInfo;
 import com.vmware.weathervane.workloadDriver.common.http.HttpRequestCompleteCallback;
 import com.vmware.weathervane.workloadDriver.common.http.HttpTransport;
 import com.vmware.weathervane.workloadDriver.common.statistics.OperationStats;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
@@ -57,7 +57,7 @@ public class Run {
 	
 	private Set<String> runningWorkloadNames = new HashSet<String>();
 	
-	private int threadPoolMultiplier = 4;
+	private int threadPoolMultiplier;
 		
 	@JsonIgnore
 	private List<String> hosts;
@@ -274,6 +274,14 @@ public class Run {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public int getThreadPoolMultiplier() {
+		return threadPoolMultiplier;
+	}
+
+	public void setThreadPoolMultiplier(int threadPoolMultiplier) {
+		this.threadPoolMultiplier = threadPoolMultiplier;
 	}
 
 	public void setWorkloads(List<Workload> workloads) {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
@@ -56,6 +56,8 @@ public class Run {
 	private LoadPathController loadPathController;
 	
 	private Set<String> runningWorkloadNames = new HashSet<String>();
+	
+	private int threadPoolMultiplier = 4;
 		
 	@JsonIgnore
 	private List<String> hosts;
@@ -79,7 +81,7 @@ public class Run {
 			System.exit(1);
 		}
 		
-		executorService = Executors.newScheduledThreadPool(4 * workloads.size());
+		executorService = Executors.newScheduledThreadPool(threadPoolMultiplier * workloads.size());
 		
 		/*
 		 * Convert all of the host names to lower case

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
@@ -116,6 +116,8 @@ public class Run {
 		if (responseEntity.getStatusCode() != HttpStatus.OK) {
 			logger.error("Error posting workload initialization to " + url);
 		}
+		
+		loadPathController.initialize(executorService);
 
 		/*
 		 * Initialize the workloads

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
@@ -60,7 +60,9 @@ public class Run {
 	private Set<String> runningWorkloadNames = new HashSet<String>();
 	
 	private int threadPoolMultiplier;
-		
+	
+	private boolean perTargetStats = false;
+			
 	@JsonIgnore
 	private List<String> hosts;
 
@@ -104,6 +106,7 @@ public class Run {
 		InitializeRunStatsMessage initializeRunStatsMessage = new InitializeRunStatsMessage();
 		initializeRunStatsMessage.setHosts(hosts);
 		initializeRunStatsMessage.setStatsOutputDirName(getStatsOutputDirName());
+		initializeRunStatsMessage.setIsPerTargetStats(perTargetStats);
 		Map<String, Integer> workloadNameToNumTargetsMap = new HashMap<String, Integer>();
 		for (Workload workload : workloads) {
 			workloadNameToNumTargetsMap.put(workload.getName(), workload.getNumTargets());
@@ -129,7 +132,7 @@ public class Run {
 		for (Workload workload : workloads) {
 			logger.debug("initialize name = " + name + ", initializing workload " + workload.getName());
 			workload.initialize(name, this, hosts, runStatsHost, workloadStatsHost,
-					loadPathController, restTemplate, executorService);
+					loadPathController, restTemplate, executorService, perTargetStats);
 		}
 		
 		state = RunState.INITIALIZED;
@@ -309,7 +312,6 @@ public class Run {
 		this.workloads = workloads;
 	}
 
-
 	public List<String> getHosts() {
 		return hosts;
 	}
@@ -356,6 +358,14 @@ public class Run {
 
 	public void setLoadPathController(LoadPathController loadPathController) {
 		this.loadPathController = loadPathController;
+	}
+
+	public boolean isPerTargetStats() {
+		return perTargetStats;
+	}
+
+	public void setPerTargetStats(boolean perTargetStats) {
+		this.perTargetStats = perTargetStats;
 	}
 
 	@Override

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -180,13 +181,13 @@ public class Run {
 		/*
 		 * Send exit messages to the other driver nodes
 		 */
-		List<ScheduledFuture<?>> sfList = new ArrayList<>();
+		List<Future<?>> sfList = new ArrayList<>();
 		for (String hostname : hosts) {
 			if (hostname.equals(workloadStatsHost)) {
 				continue;
 			}
 			
-			sfList.add(executorService.schedule(new Runnable() {
+			sfList.add(executorService.submit(new Runnable() {
 				
 				@Override
 				public void run() {
@@ -202,7 +203,7 @@ public class Run {
 						logger.error("Error posting workload to " + url);
 					}
 				}
-			}, 0, TimeUnit.MILLISECONDS));
+			}));
 		}
 		/*
 		 * Now wait for all of the nodes to be notified of the exit

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
@@ -58,9 +58,7 @@ public class Run {
 	private LoadPathController loadPathController;
 	
 	private Set<String> runningWorkloadNames = new HashSet<String>();
-	
-	private int threadPoolMultiplier;
-	
+		
 	private boolean perTargetStats = false;
 			
 	@JsonIgnore
@@ -85,7 +83,7 @@ public class Run {
 			System.exit(1);
 		}
 		
-		executorService = Executors.newScheduledThreadPool(threadPoolMultiplier * Runtime.getRuntime().availableProcessors());
+		executorService = Executors.newScheduledThreadPool(3 * workloads.size());
 		
 		/*
 		 * Convert all of the host names to lower case
@@ -124,7 +122,11 @@ public class Run {
 			logger.error("Error posting workload initialization to " + url);
 		}
 		
-		loadPathController.initialize(executorService);
+		/*
+		 * Let the loadPathController know how many workloads there
+		 * are so that it can size resources.
+		 */
+		loadPathController.initialize(workloads.size());
 
 		/*
 		 * Initialize the workloads
@@ -298,14 +300,6 @@ public class Run {
 
 	public void setName(String name) {
 		this.name = name;
-	}
-
-	public int getThreadPoolMultiplier() {
-		return threadPoolMultiplier;
-	}
-
-	public void setThreadPoolMultiplier(int threadPoolMultiplier) {
-		this.threadPoolMultiplier = threadPoolMultiplier;
 	}
 
 	public void setWorkloads(List<Workload> workloads) {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
@@ -83,7 +83,7 @@ public class Run {
 			System.exit(1);
 		}
 		
-		executorService = Executors.newScheduledThreadPool(threadPoolMultiplier * workloads.size());
+		executorService = Executors.newScheduledThreadPool(threadPoolMultiplier * Runtime.getRuntime().availableProcessors());
 		
 		/*
 		 * Convert all of the host names to lower case

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/User.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/User.java
@@ -25,7 +25,7 @@ import com.vmware.weathervane.workloadDriver.common.core.target.Target;
 import com.vmware.weathervane.workloadDriver.common.factory.OperationFactory;
 import com.vmware.weathervane.workloadDriver.common.factory.TransitionChooserFactory;
 import com.vmware.weathervane.workloadDriver.common.http.HttpTransport;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 /**
  * @author Hal

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
@@ -137,7 +137,7 @@ public abstract class Workload implements UserFactory {
 		int nodeNum = 0;
 		List<ScheduledFuture<?>> sfList = new ArrayList<>();
 		for (String hostname : hosts) {
-			sfList.add(executorService.schedule(new SendInitMsgRunner(nodeNum), 0, TimeUnit.MILLISECONDS));
+			sfList.add(executorService.schedule(new SendInitMsgRunner(nodeNum, hostname, hosts.size()), 0, TimeUnit.MILLISECONDS));
 			nodeNum++;
 		}
 		/*
@@ -170,9 +170,14 @@ public abstract class Workload implements UserFactory {
 
 	private class SendInitMsgRunner implements Runnable {
 		private int nodeNum;
+		private String hostname;
+		private int numNodes;
 
-		public SendInitMsgRunner(int nodeNum) {
+		public SendInitMsgRunner(int nodeNum, String hostname, int numNodes) {
+			super();
 			this.nodeNum = nodeNum;
+			this.hostname = hostname;
+			this.numNodes = numNodes;
 		}
 
 		@Override
@@ -180,7 +185,7 @@ public abstract class Workload implements UserFactory {
 			InitializeWorkloadMessage msg = new InitializeWorkloadMessage();
 			msg.setHostname(hostname);
 			msg.setNodeNumber(nodeNum);
-			msg.setNumNodes(hosts.size());
+			msg.setNumNodes(numNodes);
 			msg.setStatsHostName(workloadStatsHost);
 			msg.setRunName(runName);
 			/*

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
@@ -6,6 +6,7 @@ package com.vmware.weathervane.workloadDriver.common.core;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -135,9 +136,9 @@ public abstract class Workload implements UserFactory {
 		 * Send initialize workload message to all of the driver nodes
 		 */
 		int nodeNum = 0;
-		List<ScheduledFuture<?>> sfList = new ArrayList<>();
+		List<Future<?>> sfList = new ArrayList<>();
 		for (String hostname : hosts) {
-			sfList.add(executorService.schedule(new SendInitMsgRunner(nodeNum, hostname, hosts.size()), 0, TimeUnit.MILLISECONDS));
+			sfList.add(executorService.submit(new SendInitMsgRunner(nodeNum, hostname, hosts.size())));
 			nodeNum++;
 		}
 		/*
@@ -270,9 +271,9 @@ public abstract class Workload implements UserFactory {
 		/*
 		 * Send stop messages to workloads on all nodes
 		 */
-		List<ScheduledFuture<?>> sfList = new ArrayList<>();
+		List<Future<?>> sfList = new ArrayList<>();
 		for (String hostname : hosts) {
-			sfList.add(executorService.schedule(new Runnable() {
+			sfList.add(executorService.submit(new Runnable() {
 				
 				@Override
 				public void run() {
@@ -297,7 +298,7 @@ public abstract class Workload implements UserFactory {
 						logger.error("Error posting workload stop to " + url);
 					}
 				}
-			}, 0, TimeUnit.MILLISECONDS));
+			}));
 		}
 		/*
 		 * Now wait for all of the nodes to be notified of the change

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
@@ -383,6 +383,7 @@ public abstract class Workload implements UserFactory {
 			
 			target.setUserLoad(targetNumUsers);
 		}
+		
 	}
 	
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadInterval/LoadInterval.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadInterval/LoadInterval.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 public abstract class LoadInterval {
 	private Long duration = null;
 
-	private String name;
+	private String name = "unset";
 	
 	public void initialize() {
 		

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadInterval/LoadInterval.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadInterval/LoadInterval.java
@@ -17,7 +17,7 @@ public abstract class LoadInterval {
 	private Long duration = null;
 
 	private String name = "unset";
-	
+		
 	public void initialize() {
 		
 	}

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/FindMaxLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/FindMaxLoadPath.java
@@ -168,12 +168,11 @@ public class FindMaxLoadPath extends LoadPath {
 		 */
 		boolean prevIntervalPassed = true;
 		if (intervalNum != 1) {
-			String curIntervalName = curInterval.getName();
-
 			/*
 			 * This is the not first interval. Need to know whether the previous interval
 			 * passed. Get the statsSummaryRollup for the previous interval
 			 */
+			String curIntervalName = curInterval.getName();
 			StatsSummaryRollup rollup = fetchStatsSummaryRollup(curIntervalName);
 
 			// For initial ramp, only interested in response-time

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/FindMaxLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/FindMaxLoadPath.java
@@ -697,6 +697,7 @@ public class FindMaxLoadPath extends LoadPath {
 		curStatusInterval.setEndUsers(curUsers);
 		curStatusInterval.setDuration(getQosPeriodSec());
 
+		loadPathController.removeIntervalResultCallback(getName());
 		workload.loadPathComplete(status);
 	}
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/FixedLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/FixedLoadPath.java
@@ -224,6 +224,7 @@ public class FixedLoadPath extends LoadPath {
 				}
 				status.setPassed(passedQos);
 				status.setLoadPathName(this.getName());
+				loadPathController.removeIntervalResultCallback(getName());
 				workload.loadPathComplete(status);
 			}
 			curPhaseInterval++;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/IntervalLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/IntervalLoadPath.java
@@ -260,6 +260,7 @@ public class IntervalLoadPath extends LoadPath {
 			status.setMaxPassIntervalName(maxPassIntervalName);
 			status.setPassed(passed);
 			status.setLoadPathName(this.getName());
+			loadPathController.removeIntervalResultCallback(getName());
 			workload.loadPathComplete(status);
 			nextInterval = uniformIntervals.get(curIntervalIndex);
 		} else {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -181,6 +181,8 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 		if (!isFinished() && (wait > 0)) {
 			logger.debug("run: sleeping for  " + wait + " seconds");
 			getExecutorService().schedule(this, wait, TimeUnit.SECONDS);
+			// The interval really starts now
+			getStatsTracker().setCurIntervalStartTime(System.currentTimeMillis());
 		}
 	}
 
@@ -296,17 +298,27 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 	}
 
 	@Override
-	public void intervalResult(String intervalName, boolean intervalResult) {
+	public void changeInterval(String intervalName, boolean intervalResult) {
 		/*
 		 * Base implementation for loadPath types that don't use the global
 		 * interval result.  We just log the result.
 		 */
 		logger.debug("intervalResult for interval {} = {}", intervalName, intervalResult);
 	}
+	
+	@Override
+	public void startNextInterval() {
+		/*
+		 * Base implementation for loadPath types that don't use the global
+		 * interval result.  We just log the result.
+		 */
+		logger.debug("startNextInterval");
+	}
 
 	protected class StatsIntervalTracker {
 
 		private long curIntervalStartTime = System.currentTimeMillis();
+
 		private long intervalStartUsers = 0;
 
 		public void statsIntervalComplete() {
@@ -374,6 +386,14 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 			
 			intervalStartUsers = intervalEndUsers;
 			curIntervalStartTime = lastIntervalEndTime;
+		}
+		
+		public long getCurIntervalStartTime() {
+			return curIntervalStartTime;
+		}
+
+		public void setCurIntervalStartTime(long curIntervalStartTime) {
+			this.curIntervalStartTime = curIntervalStartTime;
 		}
 	}
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -258,7 +258,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 
 		String url = "http://" + statsHostName + "/stats/run/" + runName + "/workload/" + workloadName
 				+ "/specName/" + getName() + "/intervalName/" + intervalNum +"/rollup";
-		logger.debug("fetchStatsSummaryRollup  getting rollup from " + statsHostName + ", url = " + url);
+		logger.info("fetchStatsSummaryRollup  getting rollup from " + statsHostName + ", url = " + url);
 		
 		/*
 		 * Need to keep getting rollup for the interval until the stats server

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -314,43 +314,64 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 			UniformLoadInterval nextInterval = getCurStatsInterval();
 			long intervalEndUsers = nextInterval.getUsers();
 			long lastIntervalEndTime = System.currentTimeMillis();
-			logger.debug("StatsIntervalWatcher run intervalStartUsers = " + intervalStartUsers + ", intervalEndUsers = " + intervalEndUsers);
+			logger.info("StatsIntervalWatcher run intervalStartUsers = " + intervalStartUsers + ", intervalEndUsers = " + intervalEndUsers);
 
 			/*
 			 * Send messages to workloadService on driver nodes that interval has completed.
 			 */
+			List<ScheduledFuture<?>> sfList = new ArrayList<>();
 			for (String hostname : hosts) {
-				/*
-				 * Send the statsIntervalComplete message for the workload to the host
-				 */
-				StatsIntervalCompleteMessage statsIntervalCompleteMessage = new StatsIntervalCompleteMessage();
-				statsIntervalCompleteMessage.setCompletedSpecName(name);
-				statsIntervalCompleteMessage.setCurIntervalName(nextInterval.getName());
-				statsIntervalCompleteMessage.setCurIntervalStartTime(curIntervalStartTime);
-				statsIntervalCompleteMessage.setLastIntervalEndTime(lastIntervalEndTime);
-				statsIntervalCompleteMessage.setIntervalStartUsers(intervalStartUsers);
-				statsIntervalCompleteMessage.setIntervalEndUsers(intervalEndUsers);
+				sfList.add(executorService.schedule(new Runnable() {
+					
+					@Override
+					public void run() {
+						/*
+						 * Send the statsIntervalComplete message for the workload to the host
+						 */
+						StatsIntervalCompleteMessage statsIntervalCompleteMessage = new StatsIntervalCompleteMessage();
+						statsIntervalCompleteMessage.setCompletedSpecName(name);
+						statsIntervalCompleteMessage.setCurIntervalName(nextInterval.getName());
+						statsIntervalCompleteMessage.setCurIntervalStartTime(curIntervalStartTime);
+						statsIntervalCompleteMessage.setLastIntervalEndTime(lastIntervalEndTime);
+						statsIntervalCompleteMessage.setIntervalStartUsers(intervalStartUsers);
+						statsIntervalCompleteMessage.setIntervalEndUsers(intervalEndUsers);
 
-				HttpHeaders requestHeaders = new HttpHeaders();
-				requestHeaders.setContentType(MediaType.APPLICATION_JSON);
+						HttpHeaders requestHeaders = new HttpHeaders();
+						requestHeaders.setContentType(MediaType.APPLICATION_JSON);
 
-				HttpEntity<StatsIntervalCompleteMessage> msgEntity = new HttpEntity<StatsIntervalCompleteMessage>(
-						statsIntervalCompleteMessage, requestHeaders);
-				String url = "http://" + hostname + "/driver/run/" + runName + "/workload/"
-						+ workloadName + "/statsIntervalComplete";
-				logger.debug("StatsIntervalWatcher run sending statsIntervalComplete message for run " + runName
-						+ ", workload " + workloadName + ", interval " + nextInterval.getName() + " to host " + hostname + ", url = " + url);
-				ResponseEntity<BasicResponse> responseEntity = restTemplate.exchange(url, HttpMethod.POST, msgEntity,
-						BasicResponse.class);
+						HttpEntity<StatsIntervalCompleteMessage> msgEntity = new HttpEntity<StatsIntervalCompleteMessage>(
+								statsIntervalCompleteMessage, requestHeaders);
+						String url = "http://" + hostname + "/driver/run/" + runName + "/workload/"
+								+ workloadName + "/statsIntervalComplete";
+						logger.info("StatsIntervalWatcher run sending statsIntervalComplete message for run " + runName
+								+ ", workload " + workloadName + ", interval " + nextInterval.getName() + " to host " + hostname + ", url = " + url);
+						ResponseEntity<BasicResponse> responseEntity = restTemplate.exchange(url, HttpMethod.POST, msgEntity,
+								BasicResponse.class);
 
-				BasicResponse response = responseEntity.getBody();
-				if (responseEntity.getStatusCode() != HttpStatus.OK) {
-					logger.error("Error posting statsIntervalComplete message to " + url);
-				} else {
-					logger.debug("StatsIntervalWatcher run sent statsIntervalComplete message for run " + runName
-							+ ", workload " + workloadName + " to host " + hostname);
-				}
+						BasicResponse response = responseEntity.getBody();
+						if (responseEntity.getStatusCode() != HttpStatus.OK) {
+							logger.error("Error posting statsIntervalComplete message to " + url);
+						} else {
+							logger.debug("StatsIntervalWatcher run sent statsIntervalComplete message for run " + runName
+									+ ", workload " + workloadName + " to host " + hostname);
+						}
+					}
+				},  0, TimeUnit.MILLISECONDS));
 			}
+			/*
+			 * Now wait for all of the nodes to be notified of the change
+			 */
+			sfList.stream().forEach(sf -> {
+				try {
+					logger.debug("statsIntervalComplete getting a result of a notification");
+					sf.get(); 
+				} catch (Exception e) {
+					logger.warn("When notifying node got exception: " + e.getMessage());
+				};
+			});
+			logger.info("Finished statsIntervalComplete for loadPath {}", name);
+
+			
 			intervalStartUsers = intervalEndUsers;
 			curIntervalStartTime = lastIntervalEndTime;
 		}

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -146,7 +146,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 
 	@Override
 	public void run() {
-		logger.debug("run for run " + runName + ", workload " + workloadName + ", loadPath " + name );
+		logger.info("run for run " + runName + ", workload " + workloadName + ", loadPath " + name );
 		
 		/*
 		 * Check whether the just completed interval was the end of a stats interval
@@ -185,7 +185,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 	}
 
 	public void changeActiveUsers(long numUsers) {
-		logger.debug("changeActiveUsers for loadPath {} to {}", name, numUsers);
+		logger.info("changeActiveUsers for loadPath {} to {}", name, numUsers);
 		numActiveUsers = numUsers;
 		List<ScheduledFuture<?>> sfList = new ArrayList<>();
 		for (String hostname : hosts) {
@@ -212,7 +212,9 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 						ResponseEntity<BasicResponse> responseEntity = null;
 						try {
 							tries--;
+							logger.info("changeActiveUsers for loadPath {}: Starting HTTP Post to {}", name, url);
 							responseEntity = restTemplate.exchange(url, HttpMethod.POST, msgEntity,	BasicResponse.class);
+							logger.info("changeActiveUsers for loadPath {}: Completed HTTP Post to {}", name, url);
 						} catch (Throwable t) {
 								logger.warn("changeActiveUsers: LoadPath {} got throwable when notifying host {} of change in active users: {}", 
 										hostname, name, t.getMessage());
@@ -242,7 +244,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 				logger.warn("When notifying node got exception: " + e.getMessage());
 			};
 		});
-
+		logger.info("Finished changeActiveUsers for loadPath {}", name);
 	}
 
 	protected StatsSummaryRollup fetchStatsSummaryRollup(String intervalNum) {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -6,6 +6,7 @@ package com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -187,9 +188,9 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 	public void changeActiveUsers(long numUsers) {
 		logger.info("changeActiveUsers for loadPath {} to {}", name, numUsers);
 		numActiveUsers = numUsers;
-		List<ScheduledFuture<?>> sfList = new ArrayList<>();
+		List<Future<?>> sfList = new ArrayList<>();
 		for (String hostname : hosts) {
-			sfList.add(executorService.schedule(new Runnable() {
+			sfList.add(executorService.submit(new Runnable() {
 				
 				@Override
 				public void run() {
@@ -230,7 +231,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 						}
 					}
 				}
-			}, 0, TimeUnit.MILLISECONDS));
+			}));
 		}
 		
 		/*
@@ -319,9 +320,9 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 			/*
 			 * Send messages to workloadService on driver nodes that interval has completed.
 			 */
-			List<ScheduledFuture<?>> sfList = new ArrayList<>();
+			List<Future<?>> sfList = new ArrayList<>();
 			for (String hostname : hosts) {
-				sfList.add(executorService.schedule(new Runnable() {
+				sfList.add(executorService.submit(new Runnable() {
 					
 					@Override
 					public void run() {
@@ -352,11 +353,11 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 						if (responseEntity.getStatusCode() != HttpStatus.OK) {
 							logger.error("Error posting statsIntervalComplete message to " + url);
 						} else {
-							logger.debug("StatsIntervalWatcher run sent statsIntervalComplete message for run " + runName
+							logger.info("StatsIntervalWatcher run sent statsIntervalComplete message for run " + runName
 									+ ", workload " + workloadName + " to host " + hostname);
 						}
 					}
-				},  0, TimeUnit.MILLISECONDS));
+				}));
 			}
 			/*
 			 * Now wait for all of the nodes to be notified of the change

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -141,7 +141,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 			logger.debug("start: Creating statsWatcher");
 			statsTracker = new StatsIntervalTracker();
 		}
-
+		
 		executorService.execute(this);
 
 	}
@@ -152,7 +152,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 
 	@Override
 	public void run() {
-		logger.info("run for run " + runName + ", workload " + workloadName + ", loadPath " + name );
+		logger.info("run for run {}, workload {}, loadPath {}", runName, workloadName, name);
 		
 		/*
 		 * Check whether the just completed interval was the end of a stats interval
@@ -255,7 +255,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 		logger.info("Finished changeActiveUsers for loadPath {}", name);
 	}
 
-	protected StatsSummaryRollup fetchStatsSummaryRollup(String intervalNum) {
+	protected StatsSummaryRollup fetchStatsSummaryRollup(String intervalName) {
 		/*
 		 * Get the statsSummaryRollup for the previous interval over all hosts and targets
 		 */
@@ -263,7 +263,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 		requestHeaders.setContentType(MediaType.APPLICATION_JSON);
 
 		String url = "http://" + statsHostName + "/stats/run/" + runName + "/workload/" + workloadName
-				+ "/specName/" + getName() + "/intervalName/" + intervalNum +"/rollup";
+				+ "/specName/" + getName() + "/intervalName/" + intervalName +"/rollup";
 		logger.info("fetchStatsSummaryRollup  getting rollup from " + statsHostName + ", url = " + url);
 		
 		/*
@@ -304,12 +304,12 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 	}
 
 	@Override
-	public void changeInterval(String intervalName, boolean intervalResult) {
+	public void changeInterval(long intervalNum, boolean intervalResult) {
 		/*
 		 * Base implementation for loadPath types that don't use the global
 		 * interval result.  We just log the result.
 		 */
-		logger.debug("intervalResult for interval {} = {}", intervalName, intervalResult);
+		logger.debug("intervalResult for interval {} = {}", intervalNum, intervalResult);
 	}
 	
 	@Override

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -126,7 +126,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 		this.statsHostName = statsHostName;
 		this.restTemplate = restTemplate;
 		this.curStatusInterval = new RampLoadInterval();
-		notifyExecutor = Executors.newFixedThreadPool(hosts.size());
+		notifyExecutor = Executors.newFixedThreadPool(8);
 	}
 
 	public void start() {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -215,7 +215,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 							responseEntity = restTemplate.exchange(url, HttpMethod.POST, msgEntity,	BasicResponse.class);
 						} catch (Throwable t) {
 								logger.warn("changeActiveUsers: LoadPath {} got throwable when notifying host {} of change in active users: {}", 
-										hostname, this.getName(), t.getMessage());
+										hostname, name, t.getMessage());
 						}
 						
 						if (responseEntity != null) {
@@ -239,8 +239,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 				logger.debug("changeActiveUsers getting a result of a notification");
 				sf.get(); 
 			} catch (Exception e) {
-				logger.warn("When notifying node for interval " + intervalName 
-						+ " get exception: " + e.getMessage());
+				logger.warn("When notifying node got exception: " + e.getMessage());
 			};
 		});
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedFindMaxLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedFindMaxLoadPath.java
@@ -140,7 +140,7 @@ public class SyncedFindMaxLoadPath extends SyncedLoadPath {
 
 	@Override
 	protected IntervalCompleteResult intervalComplete() {
-		logger.debug("intervalComplete: " + this.getName());
+		logger.info("intervalComplete: " + this.getName());
 		statsIntervalComplete = false;
 		if (Phase.INITIALRAMP.equals(curPhase)) {
 			return initialRampIntervalComplete();			
@@ -152,8 +152,7 @@ public class SyncedFindMaxLoadPath extends SyncedLoadPath {
 	@JsonIgnore
 	@Override
 	public UniformLoadInterval getNextIntervalSynced(boolean passed) {
-
-		logger.debug("getNextIntervalSynced: " + this.getName());
+		logger.info("getNextIntervalSynced: " + this.getName());
 		statsIntervalComplete = false;
 		if (Phase.INITIALRAMP.equals(curPhase)) {
 			curInterval = getNextInitialRampInterval(passed);			
@@ -217,7 +216,7 @@ public class SyncedFindMaxLoadPath extends SyncedLoadPath {
 			result.setPassed(true);			
 		}
 		
-		logger.debug("initialRampIntervalComplete " + this.getName() 
+		logger.info("initialRampIntervalComplete " + this.getName() 
 			+ ": Interval " + intervalNum + " prevIntervalPassed = "
 			+ prevIntervalPassed);
 		return result;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedFindMaxLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedFindMaxLoadPath.java
@@ -747,6 +747,7 @@ public class SyncedFindMaxLoadPath extends SyncedLoadPath {
 		curStatusInterval.setEndUsers(curUsers);
 		curStatusInterval.setDuration(getQosPeriodSec());
 
+		loadPathController.removeIntervalResultCallback(getName());
 		workload.loadPathComplete(status);
 	}
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
@@ -20,7 +20,8 @@ public abstract class SyncedLoadPath extends LoadPath {
 	
 	@Override
 	public void run() {
-		logger.info("run for run " + runName + ", workload " + workloadName + ", loadPath " + getName() );
+		logger.info("run for run " + runName + ", workload " + workloadName + ", loadPath " + getName() 
+		+ ", isStatsInterval " + getIsStatsInterval() + ", isStatsIntervalComplete " + isStatsIntervalComplete());
 		
 		/*
 		 * Check whether the just completed interval was the end of a stats interval
@@ -54,14 +55,14 @@ public abstract class SyncedLoadPath extends LoadPath {
 	
 	@Override
 	public void changeInterval(String intervalName, boolean intervalResult) {
-		logger.info("intervalResult for interval {} = {}", intervalName, intervalResult);
+		logger.info("changeInterval for interval {} = {}", intervalName, intervalResult);
 		
 		if (!intervalName.equals(curIntervalName)) {
 			/*
 			 *  Got a result for the wrong interval.  Something
 			 *  has gone wrong so we end things here.
 			 */
-			logger.warn("intervalResult: expecting result for interval {}, got result for interval {}", 
+			logger.warn("changeInterval: expecting result for interval {}, got result for interval {}", 
 					curIntervalName, intervalName);
 			WorkloadStatus status = new WorkloadStatus();
 			status.setIntervalStatsSummaries(getIntervalStatsSummaries());
@@ -75,7 +76,7 @@ public abstract class SyncedLoadPath extends LoadPath {
 		}
 		
 		UniformLoadInterval nextInterval = this.getNextIntervalSynced(intervalResult);
-		logger.debug("intervalResult: nextInterval = " + nextInterval);
+		logger.debug("changeInterval: nextInterval = " + nextInterval);
 		long users = nextInterval.getUsers();
 		nextIntervalWait = nextInterval.getDuration();
 
@@ -92,7 +93,7 @@ public abstract class SyncedLoadPath extends LoadPath {
 		try {
 			changeActiveUsers(users);
 		} catch (Throwable t) {
-			logger.warn("intervalResult: LoadPath {} got throwable when notifying hosts of change in active users: {}", 
+			logger.warn("changeInterval: LoadPath {} got throwable when notifying hosts of change in active users: {}", 
 							this.getName(), t.getMessage());
 		}
 	}
@@ -101,7 +102,7 @@ public abstract class SyncedLoadPath extends LoadPath {
 	public void startNextInterval() {
 		logger.debug("startNextInterval: interval duration is " + nextIntervalWait + " seconds");
 		if (!isFinished() && (nextIntervalWait > 0)) {
-			logger.debug("run: sleeping for  " + nextIntervalWait + " seconds");
+			logger.debug("startNextInterval: sleeping for  " + nextIntervalWait + " seconds");
 			getExecutorService().schedule(this, nextIntervalWait, TimeUnit.SECONDS);
 			// The interval really starts now
 			getStatsTracker().setCurIntervalStartTime(System.currentTimeMillis());

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
@@ -100,7 +100,7 @@ public abstract class SyncedLoadPath extends LoadPath {
 	
 	@Override
 	public void startNextInterval() {
-		logger.debug("startNextInterval: interval duration is " + nextIntervalWait + " seconds");
+		logger.info("startNextInterval: interval duration is " + nextIntervalWait + " seconds");
 		if (!isFinished() && (nextIntervalWait > 0)) {
 			logger.debug("startNextInterval: sleeping for  " + nextIntervalWait + " seconds");
 			getExecutorService().schedule(this, nextIntervalWait, TimeUnit.SECONDS);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
@@ -19,7 +19,7 @@ public abstract class SyncedLoadPath extends LoadPath {
 	
 	@Override
 	public void run() {
-		logger.debug("run for run " + runName + ", workload " + workloadName + ", loadPath " + getName() );
+		logger.info("run for run " + runName + ", workload " + workloadName + ", loadPath " + getName() );
 		
 		/*
 		 * Check whether the just completed interval was the end of a stats interval
@@ -52,7 +52,7 @@ public abstract class SyncedLoadPath extends LoadPath {
 	
 	@Override
 	public void intervalResult(String intervalName, boolean intervalResult) {
-		logger.debug("intervalResult for interval {} = {}", intervalName, intervalResult);
+		logger.info("intervalResult for interval {} = {}", intervalName, intervalResult);
 		
 		if (!intervalName.equals(curIntervalName)) {
 			/*

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -80,19 +81,18 @@ public abstract class BaseLoadPathController implements LoadPathController {
 		 * Notify the watchers in parallel to avoid waiting for all of the driver nodes 
 		 * to be notified of changes in the number of users
 		 */
-		List<ScheduledFuture<?>> sfList = new ArrayList<>();
+		List<Future<?>> sfList = new ArrayList<>();
 		for (Entry<String, LoadPathIntervalResultWatcher> entry : watchers.entrySet()) {
 			logger.debug("notifyWatchers for interval {}, scheduling a notification", intervalName);
-			ScheduledFuture<?> sf = executorService.schedule(new Runnable() {
+			sfList.add(executorService.submit(new Runnable() {
 				
 				@Override
 				public void run() {
 					logger.info("notifyWatchers for interval {}, in scheduled notification");
 					entry.getValue().intervalResult(intervalName, passed);					
 				}
-			}, 0, TimeUnit.MILLISECONDS);
+			}));
 			logger.debug("notifyWatchers for interval {}, scheduled a notification", intervalName);
-			sfList.add(sf);
 		}
 		logger.debug("notifyWatchers for interval {}, scheduled all notifications", intervalName, passed);
 		

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -9,16 +9,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.vmware.weathervane.workloadDriver.common.core.Workload;
-import com.vmware.weathervane.workloadDriver.common.core.loadControl.loadInterval.RampLoadInterval;
 
 public abstract class BaseLoadPathController implements LoadPathController {
 
@@ -32,12 +28,11 @@ public abstract class BaseLoadPathController implements LoadPathController {
 	protected Map<String, Boolean> intervalCombinedResults = new HashMap<>();	
 	protected Map<String, Boolean> loadPathIndividualResults = new HashMap<>();
 	
-
-	private ScheduledExecutorService executorService;
-
+	private ExecutorService executorService;
+	
 	@Override
-	public void initialize(ScheduledExecutorService executorService) {
-		this.executorService = executorService;
+	public void initialize(int numWorkloads) {
+		executorService = Executors.newFixedThreadPool(numWorkloads);
 	}
 	
 	@Override

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -46,6 +46,16 @@ public abstract class BaseLoadPathController implements LoadPathController {
 	}
 
 	@Override
+	public void removeIntervalResultCallback(String name) {
+		logger.debug("removeIntervalResultCallback for loadPath {}", name);
+
+		watchers.remove(name);
+		numWatchers--;
+		logger.debug("registerIntervalResultCallback for loadPath {}, numWatchers = {}", 
+				name, numWatchers);
+	}
+
+	@Override
 	public synchronized void postIntervalResult(String loadPathName, Long intervalNum, boolean passed) {
 		logger.info("postIntervalResult for loadPath {}, interval {}, passed {}",
 				loadPathName, intervalNum, passed);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -22,10 +22,10 @@ public abstract class BaseLoadPathController implements LoadPathController {
 
 	protected Map<String, LoadPathIntervalResultWatcher> watchers = new HashMap<>();
 	protected int numWatchers = 0;
-	protected Map<String, Integer> numIntervalResults = new HashMap<>();
+	protected Map<Long, Integer> numIntervalResults = new HashMap<>();
 
 	boolean useCombinedResults = true;
-	protected Map<String, Boolean> intervalCombinedResults = new HashMap<>();	
+	protected Map<Long, Boolean> intervalCombinedResults = new HashMap<>();	
 	protected Map<String, Boolean> loadPathIndividualResults = new HashMap<>();
 	
 	private ExecutorService executorService;
@@ -46,39 +46,42 @@ public abstract class BaseLoadPathController implements LoadPathController {
 	}
 
 	@Override
-	public synchronized void postIntervalResult(String loadPathName, String intervalName, boolean passed) {
+	public synchronized void postIntervalResult(String loadPathName, Long intervalNum, boolean passed) {
+		logger.info("postIntervalResult for loadPath {}, interval {}, passed {}",
+				loadPathName, intervalNum, passed);
+
 		loadPathIndividualResults.put(loadPathName, passed);
 		
 		int curNumResults = 0;
-		if (!numIntervalResults.containsKey(intervalName)) {
+		if (!numIntervalResults.containsKey(intervalNum)) {
 			curNumResults = 1;
-			intervalCombinedResults.put(intervalName, passed);
+			intervalCombinedResults.put(intervalNum, passed);
 		} else {
-			curNumResults = numIntervalResults.get(intervalName) + 1;
+			curNumResults = numIntervalResults.get(intervalNum) + 1;
 			boolean isLastInInterval = false;
 			if (curNumResults == numWatchers) {
 				isLastInInterval = true;
 			}
-			intervalCombinedResults.put(intervalName, 
-					combineIntervalResults(intervalCombinedResults.get(intervalName), passed, isLastInInterval));
+			intervalCombinedResults.put(intervalNum, 
+					combineIntervalResults(intervalCombinedResults.get(intervalNum), passed, isLastInInterval));
 		}
-		numIntervalResults.put(intervalName, curNumResults);
+		numIntervalResults.put(intervalNum, curNumResults);
 
 		logger.debug("postIntervalResult for loadPath {}, interval {}, passed {}, curNumResults {}, numWatchers {}, result: {}",
-				loadPathName, intervalName, passed, curNumResults, numWatchers, intervalCombinedResults.get(intervalName));
+				loadPathName, intervalNum, passed, curNumResults, numWatchers, intervalCombinedResults.get(intervalNum));
 		if (curNumResults == numWatchers) {
 			logger.debug("postIntervalResult notifying watchers for interval {} with result {}", 
-					intervalName, intervalCombinedResults.get(intervalName));
-			notifyWatchers(intervalName);
+					intervalNum, intervalCombinedResults.get(intervalNum));
+			notifyWatchers(intervalNum);
 		}
 	}
 	
 	protected abstract boolean combineIntervalResults(boolean previousResult, 
 									boolean latestResult, boolean isLastInInterval);
 	
-	protected void notifyWatchers(String intervalName) {
-		logger.info("notifyWatchers for interval {}", intervalName);
-		boolean intervalCombinedResult = intervalCombinedResults.get(intervalName);
+	protected void notifyWatchers(long intervalNum) {
+		logger.info("notifyWatchers for interval {}", intervalNum);
+		boolean intervalCombinedResult = intervalCombinedResults.get(intervalNum);
 		/*
 		 * Notify the watchers in parallel to avoid waiting for all of the driver nodes 
 		 * to be notified of changes in the number of users.
@@ -88,38 +91,38 @@ public abstract class BaseLoadPathController implements LoadPathController {
 		for (Entry<String, LoadPathIntervalResultWatcher> entry : watchers.entrySet()) {
 			String loadPathName = entry.getKey();
 			logger.debug("notifyWatchers for loadPath {}, interval {}, scheduling a notification", 
-					loadPathName, intervalName);
+					loadPathName, intervalNum);
 			sfList.add(executorService.submit(new Runnable() {
 				
 				@Override
 				public void run() {
 					logger.info("notifyWatchers for loadPath {}, interval {}, in scheduled notification", 
-							loadPathName, intervalName);
+							loadPathName, intervalNum);
 					boolean loadPathResult = intervalCombinedResult;
 					if (!useCombinedResults) {
 						loadPathResult = loadPathIndividualResults.get(loadPathName);
 					}
-					entry.getValue().changeInterval(intervalName, loadPathResult);					
+					entry.getValue().changeInterval(intervalNum, loadPathResult);					
 				}
 			}));
 			logger.debug("notifyWatchers for loadPath {},  interval {}, scheduled a notification", 
-					loadPathName, intervalName);
+					loadPathName, intervalNum);
 		}
-		logger.debug("notifyWatchers for interval {}, scheduled all notifications", intervalName);
+		logger.debug("notifyWatchers for interval {}, scheduled all notifications", intervalNum);
 		
 		/*
 		 * Now wait for all of the watchers to be notified of the change in interval
 		 */
 		sfList.stream().forEach(sf -> {
 			try {
-				logger.debug("notifyWatchers for interval {}, getting a result of a notification", intervalName);
+				logger.debug("notifyWatchers for interval {}, getting a result of a notification", intervalNum);
 				sf.get(); 
 			} catch (Exception e) {
-				logger.warn("When notifying watcher for interval " + intervalName 
+				logger.warn("When notifying watcher for interval " + intervalNum 
 						+ " got exception: " + e.getMessage());
 			};
 		});
-		logger.info("notifyWatchers complete for interval {}", intervalName);
+		logger.info("notifyWatchers complete for interval {}", intervalNum);
 		
 		
 		/*

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -4,20 +4,35 @@ SPDX-License-Identifier: BSD-2-Clause
 */
 package com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPathController;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vmware.weathervane.workloadDriver.common.core.Workload;
+import com.vmware.weathervane.workloadDriver.common.core.loadControl.loadInterval.RampLoadInterval;
+
 public abstract class BaseLoadPathController implements LoadPathController {
+
 	private static final Logger logger = LoggerFactory.getLogger(BaseLoadPathController.class);
 
 	protected Map<String, LoadPathIntervalResultWatcher> watchers = new HashMap<>();
 	protected int numWatchers = 0;
 	protected Map<String, Integer> numIntervalResults = new HashMap<>();
 	protected Map<String, Boolean> intervalResults = new HashMap<>();
+
+	private ScheduledExecutorService executorService;
+
+	public void initialize(ScheduledExecutorService executorService) {
+		this.executorService = executorService;
+	}
 	
 	@Override
 	public void registerIntervalResultCallback(String name, LoadPathIntervalResultWatcher watcher) {
@@ -59,9 +74,41 @@ public abstract class BaseLoadPathController implements LoadPathController {
 									boolean latestResult, boolean isLastInInterval);
 	
 	protected void notifyWatchers(String intervalName, boolean passed) {
+		logger.debug("notifyWatchers for interval {}, result = {}", intervalName, passed);
+		/*
+		 * Notify the watchers in parallel to avoid waiting for all of the driver nodes 
+		 * to be notified of changes in the number of users
+		 */
+		List<ScheduledFuture<?>> sfList = new ArrayList<>();
 		for (Entry<String, LoadPathIntervalResultWatcher> entry : watchers.entrySet()) {
-			entry.getValue().intervalResult(intervalName, passed);
+			logger.debug("notifyWatchers for interval {}, scheduling a notification", intervalName);
+			ScheduledFuture<?> sf = executorService.schedule(new Runnable() {
+				
+				@Override
+				public void run() {
+					logger.debug("notifyWatchers for interval {}, in scheduled notification");
+					entry.getValue().intervalResult(intervalName, passed);					
+				}
+			}, 0, TimeUnit.SECONDS);
+			logger.debug("notifyWatchers for interval {}, scheduled a notification", intervalName);
+			sfList.add(sf);
 		}
+		logger.debug("notifyWatchers for interval {}, scheduled all notifications", intervalName, passed);
+		
+		/*
+		 * Now wait for all of the watchers to be notified
+		 */
+		sfList.stream().forEach(sf -> {
+			try {
+				logger.debug("notifyWatchers for interval {}, getting a result of a notification", intervalName, passed);
+				sf.get(); 
+			} catch (Exception e) {
+				logger.warn("When notifying watcher for interval " + intervalName 
+						+ " get exception: " + e.getMessage());
+			};
+		});
 	}
+	
+	
 	
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -105,7 +105,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 				sf.get(); 
 			} catch (Exception e) {
 				logger.warn("When notifying watcher for interval " + intervalName 
-						+ " get exception: " + e.getMessage());
+						+ " got exception: " + e.getMessage());
 			};
 		});
 	}

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -30,6 +30,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 
 	private ScheduledExecutorService executorService;
 
+	@Override
 	public void initialize(ScheduledExecutorService executorService) {
 		this.executorService = executorService;
 	}
@@ -89,7 +90,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 					logger.debug("notifyWatchers for interval {}, in scheduled notification");
 					entry.getValue().intervalResult(intervalName, passed);					
 				}
-			}, 0, TimeUnit.SECONDS);
+			}, 0, TimeUnit.MILLISECONDS);
 			logger.debug("notifyWatchers for interval {}, scheduled a notification", intervalName);
 			sfList.add(sf);
 		}

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -75,7 +75,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 									boolean latestResult, boolean isLastInInterval);
 	
 	protected void notifyWatchers(String intervalName, boolean passed) {
-		logger.debug("notifyWatchers for interval {}, result = {}", intervalName, passed);
+		logger.info("notifyWatchers for interval {}, result = {}", intervalName, passed);
 		/*
 		 * Notify the watchers in parallel to avoid waiting for all of the driver nodes 
 		 * to be notified of changes in the number of users
@@ -87,7 +87,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 				
 				@Override
 				public void run() {
-					logger.debug("notifyWatchers for interval {}, in scheduled notification");
+					logger.info("notifyWatchers for interval {}, in scheduled notification");
 					entry.getValue().intervalResult(intervalName, passed);					
 				}
 			}, 0, TimeUnit.MILLISECONDS);
@@ -108,6 +108,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 						+ " got exception: " + e.getMessage());
 			};
 		});
+		logger.info("notifyWatchers complete for interval {}", intervalName);
 	}
 	
 	

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathController.java
@@ -29,4 +29,6 @@ public interface LoadPathController {
 	void registerIntervalResultCallback(String name, LoadPathIntervalResultWatcher watcher);
 
 	void initialize(int numLoadPaths);
+
+	void removeIntervalResultCallback(String name);
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathController.java
@@ -4,6 +4,8 @@ SPDX-License-Identifier: BSD-2-Clause
 */
 package com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPathController;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
@@ -27,4 +29,6 @@ public interface LoadPathController {
 	void postIntervalResult(String loadPathName, String intervalName, boolean passed);
 	
 	void registerIntervalResultCallback(String name, LoadPathIntervalResultWatcher watcher);
+
+	void initialize(ScheduledExecutorService executorService);
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathController.java
@@ -4,11 +4,9 @@ SPDX-License-Identifier: BSD-2-Clause
 */
 package com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPathController;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
 @JsonTypeInfo(use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "type")
@@ -30,5 +28,5 @@ public interface LoadPathController {
 	
 	void registerIntervalResultCallback(String name, LoadPathIntervalResultWatcher watcher);
 
-	void initialize(ScheduledExecutorService executorService);
+	void initialize(int numLoadPaths);
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathController.java
@@ -24,7 +24,7 @@ public interface LoadPathController {
 	 * @param intervalName The name of the interval to which this result belongs
 	 * @param passed True if the interval passed, false otherwise
 	 */
-	void postIntervalResult(String loadPathName, String intervalName, boolean passed);
+	void postIntervalResult(String loadPathName, Long intervalNum, boolean passed);
 	
 	void registerIntervalResultCallback(String name, LoadPathIntervalResultWatcher watcher);
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathIntervalResultWatcher.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathIntervalResultWatcher.java
@@ -5,7 +5,8 @@ SPDX-License-Identifier: BSD-2-Clause
 package com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPathController;
 
 public interface LoadPathIntervalResultWatcher {
-	void changeInterval(String intervalName, boolean intervalResult);
 
 	void startNextInterval();
+
+	void changeInterval(long intervalNum, boolean intervalResult);
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathIntervalResultWatcher.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/LoadPathIntervalResultWatcher.java
@@ -5,5 +5,7 @@ SPDX-License-Identifier: BSD-2-Clause
 package com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPathController;
 
 public interface LoadPathIntervalResultWatcher {
-	void intervalResult(String intervalName, boolean intervalResult);
+	void changeInterval(String intervalName, boolean intervalResult);
+
+	void startNextInterval();
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/SyncUntilHalfFailThenAsyncLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/SyncUntilHalfFailThenAsyncLoadPathController.java
@@ -24,6 +24,9 @@ public class SyncUntilHalfFailThenAsyncLoadPathController extends BaseLoadPathCo
 			 * Once all loadPaths fail an interval, we treat this as an async
 			 * loadPath and just return to each loadPath its own result
 			 */
+			logger.info(
+					"postIntervalResult for loadPath {}, interval {}, passed {}, In runAsync",
+					loadPathName, intervalName, passed);
 			watchers.get(loadPathName).intervalResult(intervalName, passed);
 		} else {
 			int curNumResults = 0;
@@ -41,11 +44,11 @@ public class SyncUntilHalfFailThenAsyncLoadPathController extends BaseLoadPathCo
 			}
 			numIntervalResults.put(intervalName, curNumResults);
 
-			logger.debug(
+			logger.info(
 					"postIntervalResult for loadPath {}, interval {}, passed {}, curNumResults {}, numWatchers {}, result: {}",
 					loadPathName, intervalName, passed, curNumResults, numWatchers, intervalResults.get(intervalName));
 			if (curNumResults == numWatchers) {
-				logger.debug("postIntervalResult notifying watchers for interval {} with result {}", intervalName,
+				logger.info("postIntervalResult notifying watchers for interval {} with result {}", intervalName,
 						intervalResults.get(intervalName));
 				numPassed = 0;
 				numFailed = 0;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/SyncUntilHalfFailThenAsyncLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/SyncUntilHalfFailThenAsyncLoadPathController.java
@@ -17,47 +17,6 @@ public class SyncUntilHalfFailThenAsyncLoadPathController extends BaseLoadPathCo
 	private int numFailed = 0;
 
 	@Override
-	public synchronized void postIntervalResult(String loadPathName, String intervalName, boolean passed) {
-		
-		if (runAsync) {
-			/*
-			 * Once all loadPaths fail an interval, we treat this as an async
-			 * loadPath and just return to each loadPath its own result
-			 */
-			logger.info(
-					"postIntervalResult for loadPath {}, interval {}, passed {}, In runAsync",
-					loadPathName, intervalName, passed);
-			watchers.get(loadPathName).intervalResult(intervalName, passed);
-		} else {
-			int curNumResults = 0;
-			if (!numIntervalResults.containsKey(intervalName)) {
-				curNumResults = 1;
-				intervalResults.put(intervalName, passed);
-			} else {
-				curNumResults = numIntervalResults.get(intervalName) + 1;
-				boolean isLastInInterval = false;
-				if (curNumResults == numWatchers) {
-					isLastInInterval = true;
-				}
-				intervalResults.put(intervalName,
-						combineIntervalResults(intervalResults.get(intervalName), passed, isLastInInterval));
-			}
-			numIntervalResults.put(intervalName, curNumResults);
-
-			logger.info(
-					"postIntervalResult for loadPath {}, interval {}, passed {}, curNumResults {}, numWatchers {}, result: {}",
-					loadPathName, intervalName, passed, curNumResults, numWatchers, intervalResults.get(intervalName));
-			if (curNumResults == numWatchers) {
-				logger.info("postIntervalResult notifying watchers for interval {} with result {}", intervalName,
-						intervalResults.get(intervalName));
-				numPassed = 0;
-				numFailed = 0;
-				notifyWatchers(intervalName, intervalResults.get(intervalName));
-			}
-		}
-	}
-
-	@Override
 	protected boolean combineIntervalResults(boolean previousResult, boolean latestResult, boolean isLastInInverval) {
 		logger.debug("combineIntervalResults previousResult = {}, latestResult = {}, isLastInInverval = {}, allFailed = {}", 
 				previousResult, latestResult, isLastInInverval, runAsync);
@@ -66,15 +25,27 @@ public class SyncUntilHalfFailThenAsyncLoadPathController extends BaseLoadPathCo
 		} else {
 			numFailed++;
 		}
-	
-		boolean combinedValue = previousResult || latestResult;
-		if (isLastInInverval && (numFailed >= numPassed)) {
+		
+		boolean combinedValue = true;
+		if (numFailed >= numPassed) {
+			combinedValue = false;
+		}
+		
+		if (isLastInInverval) {
+			numPassed = 0;
+			numFailed = 0;
+
+			if (runAsync) {
+				useCombinedResults = false;
+			}
+			
 			/*
 			 * Switch to running async when more instances fail in
-			 * an interval than pass 
+			 * an interval than pass.  This takes effect next interval 
 			 */
-			runAsync = true;
-			combinedValue = false;
+			if (!combinedValue) {
+				runAsync = true;
+			}
 		}
 		logger.debug("combineIntervalResults combinedValue = {}", combinedValue);
 		return combinedValue;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/target/HttpTarget.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/target/HttpTarget.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.vmware.weathervane.workloadDriver.common.factory.UserFactory;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 @JsonTypeName(value = "http")
 public class HttpTarget extends Target {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/target/Target.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/target/Target.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.vmware.weathervane.workloadDriver.common.core.LoadProfileChangeCallback;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.factory.UserFactory;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 @JsonTypeInfo(use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "type")
 @JsonSubTypes({ @Type(value = HttpTarget.class, name = "http")
@@ -110,7 +110,7 @@ public abstract class Target {
 			long globalOrderingId = orderingId + targetOrderingId + targetStep;
 			logger.info("initialize: Target " + name + " creating User with userId = " + userId + ", orderingId = " + orderingId + ", globalOrderingId = " + globalOrderingId );
 			User user = getUserFactory().createUser(userId, orderingId, globalOrderingId, this);
-			user.setStatsCollector(getStatsCollector());
+			user.setStatsCollector(statsCollector);
 			this.registerLoadProfileChangeCallback(user);
 		}
 	}
@@ -213,9 +213,4 @@ public abstract class Target {
 	public UserFactory getUserFactory() {
 		return userFactory;
 	}
-
-	public StatsCollector getStatsCollector() {
-		return statsCollector;
-	}
-
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/factory/OperationFactory.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/factory/OperationFactory.java
@@ -10,7 +10,7 @@ import com.vmware.weathervane.workloadDriver.common.core.Operation;
 import com.vmware.weathervane.workloadDriver.common.core.Behavior;
 import com.vmware.weathervane.workloadDriver.common.core.User;
 import com.vmware.weathervane.workloadDriver.common.core.target.Target;
-import com.vmware.weathervane.workloadDriver.common.statistics.StatsCollector;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsCollector.StatsCollector;
 
 public interface OperationFactory {
 	List<Operation> getOperations(StatsCollector statsCollector, User user, Behavior behavior, Target target);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/representation/InitializeRunStatsMessage.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/representation/InitializeRunStatsMessage.java
@@ -13,6 +13,7 @@ public class InitializeRunStatsMessage {
 	private List<String> hosts;
 	private String statsOutputDirName;
 	private Map<String, Integer> workloadNameToNumTargetsMap;
+	private Boolean isPerTargetStats;
 	
 	public List<String> getHosts() {
 		return hosts;
@@ -59,6 +60,14 @@ public class InitializeRunStatsMessage {
 
 	public void setWorkloadNameToNumTargetsMap(Map<String, Integer> workloadNameToNumTargetsMap) {
 		this.workloadNameToNumTargetsMap = workloadNameToNumTargetsMap;
+	}
+
+	public Boolean getIsPerTargetStats() {
+		return isPerTargetStats;
+	}
+
+	public void setIsPerTargetStats(Boolean isPerTargetStats) {
+		this.isPerTargetStats = isPerTargetStats;
 	}
 	
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/representation/InitializeWorkloadMessage.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/representation/InitializeWorkloadMessage.java
@@ -14,6 +14,7 @@ public class InitializeWorkloadMessage {
 	private BehaviorSpec behaviorSpec;
 	private String statsHostName;
 	private String runName;
+	private Boolean perTargetStats;
 	
 	public String getHostname() {
 		return hostname;
@@ -50,6 +51,12 @@ public class InitializeWorkloadMessage {
 	}
 	public void setRunName(String runName) {
 		this.runName = runName;
+	}
+	public Boolean isPerTargetStats() {
+		return perTargetStats;
+	}
+	public void setPerTargetStats(Boolean perTargetStats) {
+		this.perTargetStats = perTargetStats;
 	}
 	
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/OperationStatsSummary.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/OperationStatsSummary.java
@@ -59,7 +59,7 @@ public class OperationStatsSummary {
 	}
 
 	public void addStats(OperationStats operationStats) {
-		logger.debug("addStats: OperationStats = " + operationStats);
+		logger.info("addStats: OperationStats = " + operationStats);
 
 		/*
 		 * Check the start and end times to make sure they were set properly
@@ -105,6 +105,8 @@ public class OperationStatsSummary {
 		}
 		
 		totalSteps += operationStats.getTotalSteps();
+		
+		logger.info("addStats: added OperationStats = " + operationStats);
 	}
 
 	public void merge(OperationStatsSummary that) {
@@ -348,7 +350,7 @@ public class OperationStatsSummary {
 		double maxLimit = mixPct + (mixPct * getMixPctTolerance());
 		
 		if ((pct < minLimit) || (pct > maxLimit)) {
-			logger.info("passedMixPct failed for operation " + operationName + ", requiredMixPct = "
+			logger.debug("passedMixPct failed for operation " + operationName + ", requiredMixPct = "
 					+ getRequiredMixPct() + ", mixTolerence = " + getMixPctTolerance() + ", pct = " 
 					+ pct + ", mixPct = " + mixPct + ", minLimit = " + minLimit 
 					+ ", maxLimit = " + maxLimit  + ", totalNumOps = " + getTotalNumOps()

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/StatsServiceImpl.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/StatsServiceImpl.java
@@ -71,7 +71,8 @@ public class StatsServiceImpl implements StatsService {
 		String statsIntervalSpecName = statsSummary.getStatsIntervalSpecName();
 		String intervalName = statsSummary.getIntervalName();
 		String targetName = statsSummary.getTargetName();
-		logger.info("postStatsSummary for runName = " + runName + ", workloadName = " + workloadName +
+		String localHostname = statsSummary.getHostName();
+		logger.info("postStatsSummary from host " + localHostname + " for runName = " + runName + ", workloadName = " + workloadName +
 				", targetName = " + targetName + ", specName = " + statsIntervalSpecName + ", intervalName = " + intervalName);
 		boolean isPerTarget = runNameToIsPerTargetStatsMap.get(runName);
 		Map<String, Integer> workloadNameToNumTargetsMap = runNameToWorkloadNameToNumTargetsMap.get(runName);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/StatsSummary.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/StatsSummary.java
@@ -320,7 +320,7 @@ public class StatsSummary {
 		if (statsSummaryRollup == null) {
 			statsSummaryRollup = new StatsSummaryRollup();
 			statsSummaryRollup.doRollup(this);
-			logger.info("getStatsIntervalLine rollup:" + statsSummaryRollup);
+			logger.debug("getStatsIntervalLine rollup:" + statsSummaryRollup);
 		}
 		
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerTargetStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerTargetStatsCollector.java
@@ -2,7 +2,7 @@
 Copyright 2017-2019 VMware, Inc.
 SPDX-License-Identifier: BSD-2-Clause
 */
-package com.vmware.weathervane.workloadDriver.common.statistics;
+package com.vmware.weathervane.workloadDriver.common.statistics.statsCollector;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,10 +27,12 @@ import com.vmware.weathervane.workloadDriver.common.core.Operation;
 import com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath.LoadPath;
 import com.vmware.weathervane.workloadDriver.common.representation.BasicResponse;
 import com.vmware.weathervane.workloadDriver.common.representation.StatsIntervalCompleteMessage;
+import com.vmware.weathervane.workloadDriver.common.statistics.OperationStats;
+import com.vmware.weathervane.workloadDriver.common.statistics.StatsSummary;
 import com.vmware.weathervane.workloadDriver.common.statistics.statsIntervalSpec.StatsIntervalSpec;
 
-public class StatsCollector  {
-	private static final Logger logger = LoggerFactory.getLogger(StatsCollector.class);
+public class PerTargetStatsCollector implements StatsCollector {
+	private static final Logger logger = LoggerFactory.getLogger(PerTargetStatsCollector.class);
 
 	private static final RestTemplate restTemplate = new RestTemplate();
 
@@ -59,7 +60,7 @@ public class StatsCollector  {
 	
 	private ExecutorService executorService = null;
 	
-	public StatsCollector(List<StatsIntervalSpec> statsIntervalSpecs, LoadPath loadPath, List<Operation> operations, String runName, String workloadName, String masterHostName, 
+	public PerTargetStatsCollector(List<StatsIntervalSpec> statsIntervalSpecs, LoadPath loadPath, List<Operation> operations, String runName, String workloadName, String masterHostName, 
 								String localHostname, BehaviorSpec behaviorSpec) {
 		this.runName = runName;
 		this.workloadName = workloadName;
@@ -83,7 +84,7 @@ public class StatsCollector  {
 		
 	}
 	
-	
+	@Override
 	public void submitOperationStats(OperationStats operationStats) {
 		logger.debug("submitOperationStats: " + operationStats);
 		String targetName = operationStats.getTargetName();
@@ -107,6 +108,7 @@ public class StatsCollector  {
 	 * For the intervalSpec that actually ended, send the rollup to the stats service
 	 * on the master node and reset the stats.
 	 */
+	@Override
 	public synchronized void statsIntervalComplete(StatsIntervalCompleteMessage completeMessage) {
 		logger.debug("statsIntervalComplete: " + completeMessage);
 
@@ -242,6 +244,11 @@ public class StatsCollector  {
 		
 	}
 	
+	@Override
+	public void setTargetNames(List<String> targetNames) {
+		this.targetNames = targetNames;
+	}
+	
 	public String getWorkloadName() {
 		return workloadName;
 	}
@@ -260,11 +267,6 @@ public class StatsCollector  {
 
 	public List<String> getTargetNames() {
 		return targetNames;
-	}
-	
-	public void setTargetNames(List<String> targetNames) {
-		this.targetNames = targetNames;
-	}
-	
+	}	
 
 }

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
@@ -131,12 +131,13 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		} finally {
 			curStatsRWLock.writeLock().unlock();
 		}
+		logger.info("statsIntervalComplete: Released writeLock" + completeMessage);
 
 		/*
 		 * Compute a StatsSummary for the operationStats in this interval, ignoring
 		 * operations that started before this interval or ended after.
 		 */
-		logger.debug("statsIntervalComplete processing curPeriodOpStats.  Number of samples is {}", curPeriodOpStats.size());
+		logger.info("statsIntervalComplete processing curPeriodOpStats.  Number of samples is {}", curPeriodOpStats.size());
 		long intervalStartTime = completeMessage.getCurIntervalStartTime();
 		long intervalEndTime = completeMessage.getLastIntervalEndTime();
 		StatsSummary curIntervalStatsSummary = 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
@@ -101,7 +101,11 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		curStatsRWLock.readLock().lock();
 		logger.debug("submitOperationStats locked readLock: " + operationStats);
 		try {
-			curStatsList.add(operationStats);
+			if (operationStats != null) {
+				curStatsList.add(operationStats);
+			} else {
+				logger.warn("submitOperationStats for workload {}, received null operationStats", workloadName);
+			}
 		} finally {
 			curStatsRWLock.readLock().unlock();
 			logger.debug("submitOperationStats unlocked readLock: " + operationStats);
@@ -116,7 +120,7 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 	 */
 	@Override
 	public synchronized void statsIntervalComplete(StatsIntervalCompleteMessage completeMessage) {
-		logger.info("statsIntervalComplete: " + completeMessage);
+		logger.info("statsIntervalComplete for workload {}: {}", workloadName, completeMessage);
 
 		/*
 		 * First take the current stats list and replace it with a fresh list so that we don't start

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
@@ -150,7 +150,8 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		long outIntervalOps = 0;
 		for (OperationStats operationStats : curPeriodOpStats) {
 			if (operationStats == null) {
-				logger.warn("statsIntervalComplete: caught null operationStats");
+				logger.warn("statsIntervalComplete: caught null operationStats. NumSamples = {}, inIntervalOps = {}, outIntervalOps = {}", 
+						curPeriodOpStats.size(), inItervalOps, outIntervalOps);
 				continue;
 			}
 			if ((operationStats.getStartTime() < intervalStartTime) || (operationStats.getEndTime() >= intervalEndTime)) {
@@ -198,7 +199,7 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		HttpEntity<StatsSummary> statsEntity = new HttpEntity<StatsSummary>(completedStats, requestHeaders);
 		String url = "http://" + masterHostName + "/stats/run/" + runName;
 		logger.info("statsIntervalComplete: Sending target summary for spec " + completedSpecName
-				+ " to url " + url + ", summary = " + completedStats);
+				+ " to url " + url);
 
 		ResponseEntity<BasicResponse> responseEntity 
 				= restTemplate.exchange(url, HttpMethod.POST, statsEntity, BasicResponse.class);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
@@ -149,16 +149,16 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		long inItervalOps = 0;
 		long outIntervalOps = 0;
 		for (OperationStats operationStats : curPeriodOpStats) {
+			if (operationStats == null) {
+				logger.warn("statsIntervalComplete: caught null operationStats");
+				continue;
+			}
 			if ((operationStats.getStartTime() < intervalStartTime) || (operationStats.getEndTime() >= intervalEndTime)) {
 				logger.debug("statsIntervalComplete processing op outside interval. startTime = {}, endTime = {}",
 						operationStats.getStartTime(), operationStats.getEndTime());
 				outIntervalOps++;
 			} else {
-				if (operationStats != null) {
-					curIntervalStatsSummary.addStats(operationStats);
-				} else {
-					logger.warn("statsIntervalComplete: Found null operationStats");
-				}
+				curIntervalStatsSummary.addStats(operationStats);
 				inItervalOps++;
 			}
 		}

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
@@ -114,7 +114,7 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 	 */
 	@Override
 	public synchronized void statsIntervalComplete(StatsIntervalCompleteMessage completeMessage) {
-		logger.debug("statsIntervalComplete: " + completeMessage);
+		logger.info("statsIntervalComplete: " + completeMessage);
 
 		/*
 		 * First take the current stats list and replace it with a fresh list so that we don't start
@@ -163,7 +163,8 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		completedStats.setIntervalName(completeMessage.getCurIntervalName());
 		completedStats.setEndActiveUsers(completeMessage.getIntervalEndUsers());
 		completedStats.setStartActiveUsers(completeMessage.getIntervalStartUsers());
-
+		completedStats.setHostName(localHostname);
+		
 		HttpHeaders requestHeaders = new HttpHeaders();
 		requestHeaders.setContentType(MediaType.APPLICATION_JSON);
 		HttpEntity<StatsSummary> statsEntity = new HttpEntity<StatsSummary>(completedStats, requestHeaders);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
@@ -146,24 +146,13 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		long intervalEndTime = completeMessage.getLastIntervalEndTime();
 		StatsSummary curIntervalStatsSummary = 
 				new StatsSummary(workloadName, operations, behaviorSpec, "all", localHostname, "");
-		long inItervalOps = 0;
-		long outIntervalOps = 0;
 		for (OperationStats operationStats : curPeriodOpStats) {
 			if (operationStats == null) {
-				logger.warn("statsIntervalComplete: caught null operationStats. NumSamples = {}, inIntervalOps = {}, outIntervalOps = {}", 
-						curPeriodOpStats.size(), inItervalOps, outIntervalOps);
+				logger.warn("statsIntervalComplete: caught null operationStats.");
 				continue;
 			}
-			if ((operationStats.getStartTime() < intervalStartTime) || (operationStats.getEndTime() >= intervalEndTime)) {
-				logger.debug("statsIntervalComplete processing op outside interval. startTime = {}, endTime = {}",
-						operationStats.getStartTime(), operationStats.getEndTime());
-				outIntervalOps++;
-			} else {
-				curIntervalStatsSummary.addStats(operationStats);
-				inItervalOps++;
-			}
+			curIntervalStatsSummary.addStats(operationStats);
 		}
-		logger.info("statsIntervalComplete processed {} inIntervalOps and {} outIntervalOps", inItervalOps, outIntervalOps);
 
 		/*
 		 * Now merge the current stats into every active statsInterval

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
@@ -150,17 +150,16 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		long outIntervalOps = 0;
 		for (OperationStats operationStats : curPeriodOpStats) {
 			if ((operationStats.getStartTime() < intervalStartTime) || (operationStats.getEndTime() >= intervalEndTime)) {
-				logger.info("statsIntervalComplete processing op outside interval. startTime = {}, endTime = {}",
+				logger.debug("statsIntervalComplete processing op outside interval. startTime = {}, endTime = {}",
 						operationStats.getStartTime(), operationStats.getEndTime());
 				outIntervalOps++;
 			} else {
+				if (operationStats != null) {
+					curIntervalStatsSummary.addStats(operationStats);
+				} else {
+					logger.warn("statsIntervalComplete: Found null operationStats");
+				}
 				inItervalOps++;
-			}
-			try {
-				curIntervalStatsSummary.addStats(operationStats);
-			} catch (Exception e) {
-				logger.warn("statsIntervalComplete processing op got exception after {} inIntervalOps and {} outIntervalOps",
-						inItervalOps, outIntervalOps);
 			}
 		}
 		logger.info("statsIntervalComplete processed {} inIntervalOps and {} outIntervalOps", inItervalOps, outIntervalOps);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
@@ -131,7 +131,7 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		} finally {
 			curStatsRWLock.writeLock().unlock();
 		}
-		
+
 		/*
 		 * Compute a StatsSummary for the operationStats in this interval, ignoring
 		 * operations that started before this interval or ended after.
@@ -142,8 +142,8 @@ public class PerWorkloadStatsCollector implements StatsCollector {
 		StatsSummary curIntervalStatsSummary = 
 				new StatsSummary(workloadName, operations, behaviorSpec, "all", localHostname, "");
 		curPeriodOpStats.stream()
-					.filter(opStats -> opStats.getStartTime() >= intervalStartTime)
-					.filter(opStats -> opStats.getEndTime() < intervalEndTime)
+//					.filter(opStats -> opStats.getStartTime() >= intervalStartTime)
+//					.filter(opStats -> opStats.getEndTime() < intervalEndTime)
 					.forEach(opStats -> curIntervalStatsSummary.addStats(opStats));
 		
 		/*

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/PerWorkloadStatsCollector.java
@@ -1,0 +1,210 @@
+/*
+Copyright 2017-2019 VMware, Inc.
+SPDX-License-Identifier: BSD-2-Clause
+*/
+package com.vmware.weathervane.workloadDriver.common.statistics.statsCollector;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import com.vmware.weathervane.workloadDriver.common.core.BehaviorSpec;
+import com.vmware.weathervane.workloadDriver.common.core.Operation;
+import com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath.LoadPath;
+import com.vmware.weathervane.workloadDriver.common.representation.BasicResponse;
+import com.vmware.weathervane.workloadDriver.common.representation.StatsIntervalCompleteMessage;
+import com.vmware.weathervane.workloadDriver.common.statistics.OperationStats;
+import com.vmware.weathervane.workloadDriver.common.statistics.StatsSummary;
+import com.vmware.weathervane.workloadDriver.common.statistics.statsIntervalSpec.StatsIntervalSpec;
+
+public class PerWorkloadStatsCollector implements StatsCollector {
+	private static final Logger logger = LoggerFactory.getLogger(PerWorkloadStatsCollector.class);
+
+	private static final RestTemplate restTemplate = new RestTemplate();
+
+	private String workloadName;
+	
+	private List<String> targetNames = null;
+	
+	private List<Operation> operations = null;
+	
+	ReentrantReadWriteLock curStatsRWLock = new ReentrantReadWriteLock(true);
+	private List<OperationStats> curStatsList = new ArrayList<>();
+	
+	private Map<String, StatsSummary> specNameToIntervalStatsMap = new HashMap<String, StatsSummary>();
+	
+	private List<StatsIntervalSpec> statsIntervalSpecs = null;
+	
+	private BehaviorSpec behaviorSpec = null;
+	
+	private String masterHostName;
+	private String localHostname;
+
+	private String runName;
+
+	private LoadPath loadPath;
+		
+	public PerWorkloadStatsCollector(List<StatsIntervalSpec> statsIntervalSpecs, LoadPath loadPath, List<Operation> operations, String runName, String workloadName, String masterHostName, 
+								String localHostname, BehaviorSpec behaviorSpec) {
+		this.runName = runName;
+		this.workloadName = workloadName;
+		this.masterHostName = masterHostName;
+		this.localHostname = localHostname;
+		this.operations = operations;
+		this.behaviorSpec = behaviorSpec;
+		this.statsIntervalSpecs = statsIntervalSpecs;
+		this.loadPath = loadPath;
+				
+		/*
+		 * A collector gets a message for each interval it uses.  The
+		 * message triggers the roll-up of stats for that interval.  Intervals
+		 * include those for each StatsCollector, as well as the intervals defined
+		 * by the LoadPath.
+		 */
+		for (StatsIntervalSpec spec : this.statsIntervalSpecs) {
+			StatsSummary specStatsSummary = new StatsSummary(workloadName, operations, behaviorSpec, 
+					"all", localHostname, spec.getName());
+			specStatsSummary.setPrintSummary(spec.getPrintSummary());
+			specStatsSummary.setPrintIntervals(spec.getPrintIntervals());
+			specStatsSummary.setPrintCsv(spec.getPrintCsv());
+			specNameToIntervalStatsMap.put(spec.getName(), specStatsSummary);
+		}
+		StatsSummary lpStatsSummary = new StatsSummary(workloadName, operations, behaviorSpec, 
+				"all", localHostname, loadPath.getName());
+		lpStatsSummary.setPrintSummary(loadPath.getPrintSummary());
+		lpStatsSummary.setPrintIntervals(loadPath.getPrintIntervals());
+		lpStatsSummary.setPrintCsv(loadPath.getPrintCsv());		
+		specNameToIntervalStatsMap.put(loadPath.getName(),lpStatsSummary);		
+	}
+	
+	@Override
+	public void submitOperationStats(OperationStats operationStats) {
+		logger.debug("submitOperationStats: " + operationStats);
+
+		/*
+		 * Add the operationStats to the list of current stats for this period.
+		 * The read lock prevents the list from being replaced while this sample
+		 * is added.  The list is replaced when a statsInterval completes.
+		 */
+		curStatsRWLock.readLock().lock();
+		try {
+			curStatsList.add(operationStats);
+		} finally {
+			curStatsRWLock.readLock().unlock();
+		}
+	}
+
+	/**
+	 * Roll the current stats for each target up into the interval stats for
+	 * all intervalSpecs.
+	 * For the intervalSpec that actually ended, send the rollup to the stats service
+	 * on the master node and reset the stats.
+	 */
+	@Override
+	public synchronized void statsIntervalComplete(StatsIntervalCompleteMessage completeMessage) {
+		logger.debug("statsIntervalComplete: " + completeMessage);
+
+		/*
+		 * First take the current stats list and replace it with a fresh list so that we don't start
+		 * counting results from the new interval
+		 */
+		List<OperationStats> curPeriodOpStats;
+		curStatsRWLock.writeLock().lock();
+		try {
+			curPeriodOpStats = curStatsList;
+			curStatsList = new ArrayList<>();
+		} finally {
+			curStatsRWLock.writeLock().unlock();
+		}
+		
+		/*
+		 * Compute a StatsSummary for the operationStats in this interval 
+		 */
+		StatsSummary curIntervalStatsSummary = 
+				new StatsSummary(workloadName, operations, behaviorSpec, "all", localHostname, "");
+		curPeriodOpStats.stream().forEach(opStats -> curIntervalStatsSummary.addStats(opStats));
+		
+		/*
+		 * Now merge the current stats into every active statsInterval
+		 */
+		for (StatsIntervalSpec spec : statsIntervalSpecs) {
+			String specName = spec.getName();
+			StatsSummary specStats = specNameToIntervalStatsMap.get(specName);
+			logger.info("statsIntervalComplete: Merging curStats into stats for spec " + specName);
+			specStats.merge(curIntervalStatsSummary);
+		}
+
+		// Do the same thing for the loadPath interval
+		String loadPathName = loadPath.getName();
+		StatsSummary lpStats = specNameToIntervalStatsMap.get(loadPathName);
+		logger.info("statsIntervalComplete: Merging curStats into stats for loadPath " + loadPathName);
+		lpStats.merge(curIntervalStatsSummary);
+		
+		/*
+		 * For the spec that actually completed an interval, send the stats to the statsService
+		 * and reset the collected stats
+		 */
+		String completedSpecName = completeMessage.getCompletedSpecName();
+		StatsSummary completedStats = specNameToIntervalStatsMap.get(completedSpecName);
+		completedStats.setIntervalStartTime(completeMessage.getCurIntervalStartTime());
+		completedStats.setIntervalEndTime(completeMessage.getLastIntervalEndTime());
+		completedStats.setIntervalName(completeMessage.getCurIntervalName());
+		completedStats.setEndActiveUsers(completeMessage.getIntervalEndUsers());
+		completedStats.setStartActiveUsers(completeMessage.getIntervalStartUsers());
+
+		HttpHeaders requestHeaders = new HttpHeaders();
+		requestHeaders.setContentType(MediaType.APPLICATION_JSON);
+		HttpEntity<StatsSummary> statsEntity = new HttpEntity<StatsSummary>(completedStats, requestHeaders);
+		String url = "http://" + masterHostName + "/stats/run/" + runName;
+		logger.info("statsIntervalComplete: Sending target summary for spec " + completedSpecName
+				+ " to url " + url + ", summary = " + completedStats);
+
+		ResponseEntity<BasicResponse> responseEntity 
+				= restTemplate.exchange(url, HttpMethod.POST, statsEntity, BasicResponse.class);
+		BasicResponse response = responseEntity.getBody();
+		if (responseEntity.getStatusCode() != HttpStatus.OK) {
+			logger.error("Error posting statsSummary to " + url);
+		}
+
+		logger.info("statsIntervalComplete: sent summary for spec " + completedSpecName + " to url " + url + ". Resetting stats");
+		completedStats.reset();								
+	}
+	
+	@Override
+	public void setTargetNames(List<String> targetNames) {
+		this.targetNames = targetNames;
+	}
+	
+	public String getWorkloadName() {
+		return workloadName;
+	}
+
+	public void setWorkloadName(String workloadName) {
+		this.workloadName = workloadName;
+	}
+
+	public String getLocalHostname() {
+		return localHostname;
+	}
+
+	public void setLocalHostname(String localHostname) {
+		this.localHostname = localHostname;
+	}
+
+	public List<String> getTargetNames() {
+		return targetNames;
+	}
+	
+}

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/StatsCollector.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsCollector/StatsCollector.java
@@ -1,0 +1,14 @@
+package com.vmware.weathervane.workloadDriver.common.statistics.statsCollector;
+
+import java.util.List;
+
+import com.vmware.weathervane.workloadDriver.common.representation.StatsIntervalCompleteMessage;
+import com.vmware.weathervane.workloadDriver.common.statistics.OperationStats;
+
+public interface StatsCollector {
+	void submitOperationStats(OperationStats operationStats);
+
+	void statsIntervalComplete(StatsIntervalCompleteMessage completeMessage);
+
+	void setTargetNames(List<String> targetNames);
+}

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsIntervalSpec/StatsIntervalSpec.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsIntervalSpec/StatsIntervalSpec.java
@@ -89,7 +89,7 @@ public abstract class StatsIntervalSpec implements Runnable {
 		this.hosts = hosts;
 		this.restTemplate = resetTemplate;
 		this.statsExecutor = executorService;	
-		notifyExecutor = Executors.newFixedThreadPool(hosts.size());
+		notifyExecutor = Executors.newFixedThreadPool(8);
 	}
 
 	public void start() {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsIntervalSpec/StatsIntervalSpec.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/statistics/statsIntervalSpec/StatsIntervalSpec.java
@@ -6,6 +6,8 @@ package com.vmware.weathervane.workloadDriver.common.statistics.statsIntervalSpe
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +62,9 @@ public abstract class StatsIntervalSpec implements Runnable {
 	private ScheduledExecutorService statsExecutor;
 
 	@JsonIgnore
+	private ExecutorService notifyExecutor;
+
+	@JsonIgnore
 	private RestTemplate restTemplate;
 
 	@JsonIgnore
@@ -83,7 +88,8 @@ public abstract class StatsIntervalSpec implements Runnable {
 		this.workloadName = workloadName;
 		this.hosts = hosts;
 		this.restTemplate = resetTemplate;
-		this.statsExecutor = executorService;				
+		this.statsExecutor = executorService;	
+		notifyExecutor = Executors.newFixedThreadPool(hosts.size());
 	}
 
 	public void start() {
@@ -118,7 +124,7 @@ public abstract class StatsIntervalSpec implements Runnable {
 		 */
 		List<Future<?>> sfList = new ArrayList<>();
 		for (String hostname : hosts) {
-			sfList.add(statsExecutor.submit(new Runnable() {
+			sfList.add(notifyExecutor.submit(new Runnable() {
 
 				@Override
 				public void run() {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/web/controller/DriverController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/web/controller/DriverController.java
@@ -115,6 +115,7 @@ public class DriverController {
 		try {
 			driverService.changeActiveUsers(runName, workloadName, changeUsersMessage.getActiveUsers());
 		} catch (Exception e) {
+			logger.warn("changeUsers: caught exception: {}", e.getMessage());
 			response.setMessage(e.getMessage());
 			response.setStatus("Failure");
 			status = HttpStatus.CONFLICT;
@@ -133,6 +134,7 @@ public class DriverController {
 		try {
 			driverService.statsIntervalComplete(runName, workloadName, statsIntervalCompleteMessage);
 		} catch (Exception e) {
+			logger.warn("statsIntervalComplete: caught exception: {}", e.getMessage());
 			response.setMessage(e.getMessage());
 			response.setStatus("Failure");
 			status = HttpStatus.CONFLICT;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/web/controller/DriverController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/web/controller/DriverController.java
@@ -43,6 +43,7 @@ public class DriverController {
 		try {
 			driverService.addRun(runName);
 		} catch (Exception e) {
+			logger.warn("addRun: caught exception: {}", e.getMessage());
 			response.setMessage(e.getMessage());
 			response.setStatus("Failure");
 			status = HttpStatus.CONFLICT;
@@ -61,6 +62,7 @@ public class DriverController {
 		try {
 			driverService.removeRun(runName);
 		} catch (Exception e) {
+			logger.warn("deleteRun: caught exception: {}", e.getMessage());
 			response.setMessage(e.getMessage());
 			response.setStatus("Failure");
 			status = HttpStatus.CONFLICT;
@@ -79,6 +81,7 @@ public class DriverController {
 		try {
 			driverService.addWorkload(runName, workloadName, theWorkload);
 		} catch (Exception e) {
+			logger.warn("addWorkload: caught exception: {}", e.getMessage());
 			response.setMessage(e.getMessage());
 			response.setStatus("Failure");
 			status = HttpStatus.CONFLICT;
@@ -97,6 +100,7 @@ public class DriverController {
 		try {
 			driverService.initializeWorkload(runName, workloadName, initializeWorkloadMessage);
 		} catch (Exception e) {
+			logger.warn("initializeWorkload: caught exception: {}", e.getMessage());
 			response.setMessage(e.getMessage());
 			response.setStatus("Failure");
 			status = HttpStatus.CONFLICT;
@@ -152,6 +156,7 @@ public class DriverController {
 		try {
 			driverService.stopWorkload(runName, workloadName);
 		} catch (Exception e) {
+			logger.warn("stopWorkload: caught exception: {}", e.getMessage());
 			response.setMessage(e.getMessage());
 			response.setStatus("Failure");
 			status = HttpStatus.CONFLICT;
@@ -170,6 +175,7 @@ public class DriverController {
 		try {
 			driverService.exit(runName);
 		} catch (Exception e) {
+			logger.warn("exit: caught exception: {}", e.getMessage());
 			response.setMessage(e.getMessage());
 			response.setStatus("Failure");
 			status = HttpStatus.CONFLICT;

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/web/controller/StatsController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/web/controller/StatsController.java
@@ -43,7 +43,8 @@ public class StatsController {
 		
 		try {
 			statsService.postStatsSummary(runName, statsSummary);
-		} catch (IOException e) {
+		} catch (Exception e) {
+			logger.warn("postStatsSummary: caught exception: {}", e.getMessage());
 			response.setMessage(e.getMessage());
 			response.setStatus("Failure");
 			status = HttpStatus.CONFLICT;


### PR DESCRIPTION
This pull request includes the following changes:
- Parallelize sending of messages among workload driver nodes.  This decreases the time required to make transitions between load-path intervals.
- Keep all workloads (appInstances) in a run (workload) in sync during the run (applies to all sub-types of syncedLoadPath).  Previously a workload could start the next interval before others.
- Make collecting csv stats and per-target stats optional.  This reduces overhead and storage requirements on the run harness pod.
- Add better logging of errors if the data preparation process fails.