### PR TITLE
Fix Driver hangs

### DIFF
--- a/runHarness/AppInstance/AppInstance.pm
+++ b/runHarness/AppInstance/AppInstance.pm
@@ -1360,7 +1360,7 @@ sub getLogFiles {
 }
 
 sub getDataServiceLogFiles {
-	my ( $self, $destinationPath ) = @_;
+	my ( $self, $baseDestinationPath ) = @_;
 	my $logger = get_logger("Weathervane::AppInstance::AppInstance");
 	$logger->debug(
 		"getDataServiceLogFiles for workload ", $self->workload->instanceNum,
@@ -1382,6 +1382,7 @@ sub getDataServiceLogFiles {
 					exit(-1);
 				}
 				elsif ( $pid == 0 ) {
+					my $destinationPath = $baseDestinationPath . "/W" .  $self->workload->instanceNum . "I" . $self->instanceNum;
 					if ( !( -e $destinationPath ) ) {
 						`mkdir -p $destinationPath`;
 					}

--- a/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
+++ b/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
@@ -151,6 +151,12 @@ override 'getEdgeAddrsRef' => sub {
 	  	$type = "InternalIP";
 	  }
 	  my $ipAddrsRef = $cluster->kubernetesGetNodeIPs($type);
+	  my $targetWeb = $self->getParamValue("nodeportTargetWeb");
+	  if ($targetWeb) {
+	  	$ipAddrsRef = $cluster->kubernetesGetNodeIPsForPodSelector($self->namespace, "impl=nginx");	  		  	
+	  } else {
+	  	$ipAddrsRef = $cluster->kubernetesGetNodeIPs($type);	  	
+	  }
 	  if ($#{$ipAddrsRef} < 0) {
 	  	 $logger->error("There are no IP addresses for the Kubernetes nodes");
 		 exit 1;

--- a/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
+++ b/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
@@ -153,7 +153,7 @@ override 'getEdgeAddrsRef' => sub {
 	  my $ipAddrsRef = $cluster->kubernetesGetNodeIPs($type);
 	  my $targetWeb = $self->getParamValue("nodeportTargetWeb");
 	  if ($targetWeb) {
-	  	$ipAddrsRef = $cluster->kubernetesGetNodeIPsForPodSelector($self->namespace, "type=webServer");	  		  	
+	  	$ipAddrsRef = $cluster->kubernetesGetNodeIPsForPodSelector("type=webServer", $self->namespace);	  		  	
 	  } else {
 	  	$ipAddrsRef = $cluster->kubernetesGetNodeIPs($type);	  	
 	  }

--- a/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
+++ b/runHarness/AppInstance/AuctionKubernetesAppInstance.pm
@@ -153,7 +153,7 @@ override 'getEdgeAddrsRef' => sub {
 	  my $ipAddrsRef = $cluster->kubernetesGetNodeIPs($type);
 	  my $targetWeb = $self->getParamValue("nodeportTargetWeb");
 	  if ($targetWeb) {
-	  	$ipAddrsRef = $cluster->kubernetesGetNodeIPsForPodSelector($self->namespace, "impl=nginx");	  		  	
+	  	$ipAddrsRef = $cluster->kubernetesGetNodeIPsForPodSelector($self->namespace, "type=webServer");	  		  	
 	  } else {
 	  	$ipAddrsRef = $cluster->kubernetesGetNodeIPs($type);	  	
 	  }

--- a/runHarness/ComputeResources/KubernetesCluster.pm
+++ b/runHarness/ComputeResources/KubernetesCluster.pm
@@ -503,7 +503,13 @@ sub kubernetesDeleteAllForCluster {
 
 					my @remaining = split /\s+/, $outString;
 					my $numRemaining = $#remaining + 1;
-					$logger->debug("kubernetesDeleteAllForCluster namespace $namespace remaining items : $numRemaining");
+                    # Ignore any system items in the namespace (starting with kube)
+                    foreach my $objectName (@remaining) {
+                      if ($objectName =~ /kube/) {
+                        $numRemaining--;
+                      }
+                    }
+                    $logger->debug("kubernetesDeleteAllForCluster namespace $namespace remaining items : $numRemaining");
 					if ($numRemaining > 0) {
 						$loopExit = 0;
 						last;
@@ -542,6 +548,9 @@ sub _kubernetesDeleteAllForClusterHelper {
 
 		my @names = split /\s+/, $outString;
 		foreach my $name (@names) {
+            if ($name =~ /kube/) {
+				next;
+            }
 			$cmd = "kubectl delete $type $name $appendCmdStr";
 			($cmdFailed, $outString) = runCmd($cmd);
 			if ($cmdFailed) {

--- a/runHarness/ComputeResources/KubernetesCluster.pm
+++ b/runHarness/ComputeResources/KubernetesCluster.pm
@@ -1230,7 +1230,9 @@ sub kubernetesGetLogs {
 		}
 
 		$logger->debug("Command: $cmd");
-		my $logName          = "$destinationPath/${podName}.log";
+		my $time = `date +%H:%M`;
+		chomp($time);
+		my $logName          = "$destinationPath/${podName}-$time.log";
 		my $applog;
 		open( $applog, ">$logName" )
 	  	||	 die "Error opening $logName:$!";

--- a/runHarness/ComputeResources/KubernetesCluster.pm
+++ b/runHarness/ComputeResources/KubernetesCluster.pm
@@ -1238,10 +1238,7 @@ sub kubernetesGetLogs {
 			$logger->error("kubernetesGetLogs logs failed: $cmdFailed");
 		}
 
-		$logger->debug("Command: $cmd");
-		my $time = `date +%H:%M`;
-		chomp($time);
-		my $logName          = "$destinationPath/${podName}-$time.log";
+		my $logName          = "$destinationPath/${podName}.log";
 		my $applog;
 		open( $applog, ">$logName" )
 	  	||	 die "Error opening $logName:$!";

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -155,8 +155,6 @@ sub stopDataManagerContainer {
 	}
 	$logger->debug("Command: $cmd");
 	$logger->debug("Output: $outString");
-	print $applog "Command: $cmd\n";
-	print $applog "Output: $outString\n";
 	
 	$cluster->kubernetesDelete("configMap", "auctiondatamanager-config", $self->appInstance->namespace);
 	$cluster->kubernetesDelete("deployment", "auctiondatamanager", $self->appInstance->namespace);
@@ -231,7 +229,9 @@ sub prepareData {
 	my $appInstance    = $self->appInstance;
 	my $retVal         = 0;
 
-	my $logName = "$logPath/PrepareData_W${workloadNum}I${appInstanceNum}.log";
+	my $time = `date +%H:%M`;
+	chomp($time);
+	my $logName = "$logPath/PrepareData-W${workloadNum}I${appInstanceNum}-$time.log";
 	my $logHandle;
 	open( $logHandle, ">>$logName" ) or do {
 		$console_logger->error("Error opening $logName:$!");
@@ -266,6 +266,7 @@ sub prepareData {
 				  . "$appInstanceNum of workload $workloadNum. Loading data." );
 
 			# Load the data
+			$appInstance->getDataServiceLogFiles($logPath);
 			$appInstance->stopServices("data", $logPath);
 			$appInstance->clearDataServicesBeforeStart($logPath);
 			$appInstance->startServices("data", $logPath, 0);
@@ -320,7 +321,10 @@ sub loadData {
 	my $workloadNum    = $self->appInstance->workload->instanceNum;
 	my $appInstanceNum = $self->appInstance->instanceNum;
 	my $cluster = $self->host;
-	my $logName          = "$logPath/loadData-W${workloadNum}I${appInstanceNum}.log";
+
+	my $time = `date +%H:%M`;
+	chomp($time);
+	my $logName          = "$logPath/loadData-W${workloadNum}I${appInstanceNum}-$time.log";
 	my $namespace = $self->appInstance->namespace;
 	
 	$logger->debug("loadData for workload $workloadNum, appInstance $appInstanceNum");
@@ -416,7 +420,10 @@ sub isDataLoaded {
 	my $appInstanceNum = $self->appInstance->instanceNum;
 	$logger->debug("isDataLoaded for workload $workloadNum, appInstance $appInstanceNum");
 
-	my $logName = "$logPath/isDataLoaded-W${workloadNum}I${appInstanceNum}.log";
+
+	my $time = `date +%H:%M`;
+	chomp($time);
+	my $logName = "$logPath/isDataLoaded-W${workloadNum}I${appInstanceNum}-$time.log";
 	my $applog;
 	open( $applog, ">$logName" )
 	  || die "Error opening /$logName:$!";

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -200,6 +200,7 @@ sub prepareDataServices {
 			# Delete the PVCs for this namespace and try again
 			$console_logger->info(
 				"Couldn't start data services for appInstance $appInstanceNum of workload $workloadNum. Clearing data and retrying.\n" );
+			$appInstance->getDataServiceLogFiles($logPath);
 			$appInstance->stopServices("data", $logPath);
 			my $cluster = $self->host;
 			my $namespace = $self->appInstance->namespace;

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -196,11 +196,11 @@ sub prepareDataServices {
 	my $allIsStarted = $appInstance->startServices("data", $logPath, 0);
 	
 	if (!$allIsStarted) {
+		$appInstance->getDataServiceLogFiles($logPath . "/prepareDataServicesFailure");
 		if ($self->getParamValue("reloadOnFailure")) {
 			# Delete the PVCs for this namespace and try again
 			$console_logger->info(
 				"Couldn't start data services for appInstance $appInstanceNum of workload $workloadNum. Clearing data and retrying.\n" );
-			$appInstance->getDataServiceLogFiles($logPath);
 			$appInstance->stopServices("data", $logPath);
 			my $cluster = $self->host;
 			my $namespace = $self->appInstance->namespace;
@@ -267,7 +267,7 @@ sub prepareData {
 				  . "$appInstanceNum of workload $workloadNum. Loading data." );
 
 			# Load the data
-			$appInstance->getDataServiceLogFiles($logPath);
+			$appInstance->getDataServiceLogFiles($logPath . "/preLoadLogs");
 			$appInstance->stopServices("data", $logPath);
 			$appInstance->clearDataServicesBeforeStart($logPath);
 			$appInstance->startServices("data", $logPath, 0);

--- a/runHarness/Parameters.pm
+++ b/runHarness/Parameters.pm
@@ -1641,6 +1641,14 @@ $parameters{"ssl"} = {
 	"showUsage" => 0,
 };
 
+$parameters{"nodeportTargetWeb"} = {
+	"type"      => "!",
+	"default"   => JSON::false,
+	"parent"    => "appInstance",
+	"usageText" => "If true, the driver will only send traffic for an instance to nodes with web pods.",
+	"showUsage" => 0,
+};
+
 $parameters{"randomizeImages"} = {
 	"type"      => "!",
 	"default"   => JSON::true,

--- a/runHarness/Services/AuctionBidDockerService.pm
+++ b/runHarness/Services/AuctionBidDockerService.pm
@@ -250,7 +250,7 @@ sub setExternalPortNumbers {
 }
 
 sub configure {
-	my ( $self, $logPath, $users, $suffix ) = @_;
+	my ( $self, $users, $suffix ) = @_;
 
 }
 

--- a/runHarness/Services/AuctionBidKubernetesService.pm
+++ b/runHarness/Services/AuctionBidKubernetesService.pm
@@ -24,10 +24,9 @@ override 'initialize' => sub {
 };
 
 sub configure {
-	my ( $self, $dblog, $serviceType, $users ) = @_;
+	my ( $self, $serviceType, $users ) = @_;
 	my $logger = get_logger("Weathervane::Services::AuctionBidKubernetesService");
 	$logger->debug("Configure AuctionBidService kubernetes");
-	print $dblog "Configure AuctionBidService Kubernetes\n";
 
 	my $namespace = $self->namespace;	
 	my $configDir        = $self->getParamValue('configDir');

--- a/runHarness/Services/CassandraDockerService.pm
+++ b/runHarness/Services/CassandraDockerService.pm
@@ -250,7 +250,7 @@ sub cleanData {
 }
 
 sub configure {
-	my ( $self, $logPath, $users, $suffix ) = @_;
+	my ( $self, $users, $suffix ) = @_;
 
 }
 

--- a/runHarness/Services/CassandraKubernetesService.pm
+++ b/runHarness/Services/CassandraKubernetesService.pm
@@ -61,10 +61,9 @@ sub clearDataAfterStart {
 }
 
 sub configure {
-	my ( $self, $dblog, $serviceType, $users ) = @_;
+	my ( $self, $serviceType, $users ) = @_;
 	my $logger = get_logger("Weathervane::Services::CassandraKubernetesService");
 	$logger->debug("Configure Cassandra kubernetes");
-	print $dblog "Configure Cassandra Kubernetes\n";
 
 	my $namespace = $self->namespace;	
 	my $configDir        = $self->getParamValue('configDir');

--- a/runHarness/Services/KubernetesService.pm
+++ b/runHarness/Services/KubernetesService.pm
@@ -33,56 +33,28 @@ override 'initialize' => sub {
 override 'stop' => sub {
 	my ($self, $serviceType, $logPath)            = @_;
 	my $logger = get_logger("Weathervane::Services::KubernetesService");
-	my $console_logger   = get_logger("Console");
 
 	my $impl = $self->getImpl();
-	
-	
-	my $time = `date +%H:%M`;
-	chomp($time);
-	my $logName     = "$logPath/Stop${impl}Kubernetes-$time.log";
-	my $appInstance = $self->appInstance;
-	
 	$logger->debug("$impl kubernetes Stop");
-	
-	my $log;
-	open( $log, ">$logName" )
-	  || die "Error opening /$logName:$!";
-	print $log $self->meta->name . " In KubernetesService::stop for $impl\n";
-		
+			
 	my $cluster = $self->host;
-	
 	$cluster->kubernetesDeleteAllWithLabel("type=$serviceType", $self->namespace);
-	close $log;
 };
 
 # Configure and Start all of the services 
 override 'start' => sub {
 	my ($self, $serviceType, $users, $logPath)            = @_;
 	my $logger = get_logger("Weathervane::Services::KubernetesService");
-	my $console_logger   = get_logger("Console");
-	my $time = `date +%H:%M`;
-	chomp($time);
-	my $impl = $self->getImpl();
-	my $logName     = "$logPath/Start${impl}Kubernetes-$time.log";
-	my $appInstance = $self->appInstance;
-	
+
+	my $impl = $self->getImpl();	
 	$logger->debug("$impl kubernetes Start");
 	
-	my $log;
-	open( $log, ">$logName" )
-	  || die "Error opening /$logName:$!";
-	print $log $self->meta->name . " In KubernetesService::start for $impl\n";
-			
 	# Create the yaml file for the service
-	$self->configure($log, $serviceType, $users);
+	$self->configure($serviceType, $users);
 			
 	my $cluster = $self->host;
 	my $namespace = $self->namespace;
 	$cluster->kubernetesApply("/tmp/${impl}-${namespace}.yaml", $namespace);
-	
-	close $log;
-
 };
 
 override 'isRunning' => sub {

--- a/runHarness/Services/NginxDockerService.pm
+++ b/runHarness/Services/NginxDockerService.pm
@@ -255,7 +255,7 @@ sub setExternalPortNumbers {
 	
 }
 sub configure {
-	my ( $self, $logPath, $users, $suffix ) = @_;
+	my ( $self, $users, $suffix ) = @_;
 
 }
 

--- a/runHarness/Services/NginxKubernetesService.pm
+++ b/runHarness/Services/NginxKubernetesService.pm
@@ -22,10 +22,9 @@ override 'initialize' => sub {
 };
 
 sub configure {
-	my ( $self, $dblog, $serviceType, $users ) = @_;
+	my ( $self, $serviceType, $users ) = @_;
 	my $logger = get_logger("Weathervane::Services::NginxService");
 	$logger->debug("Configure Nginx kubernetes");
-	print $dblog "Configure Nginx Kubernetes\n";
 
 	my $namespace = $self->namespace;	
 	my $configDir        = $self->getParamValue('configDir');

--- a/runHarness/Services/PostgresqlDockerService.pm
+++ b/runHarness/Services/PostgresqlDockerService.pm
@@ -242,7 +242,7 @@ sub setExternalPortNumbers {
 }
 
 sub configure {
-	my ( $self, $logPath, $users, $suffix ) = @_;
+	my ( $self, $users, $suffix ) = @_;
 
 }
 

--- a/runHarness/Services/PostgresqlKubernetesService.pm
+++ b/runHarness/Services/PostgresqlKubernetesService.pm
@@ -54,10 +54,9 @@ sub clearDataAfterStart {
 }
 
 sub configure {
-	my ( $self, $dblog, $serviceType, $users ) = @_;
+	my ( $self, $serviceType, $users ) = @_;
 	my $logger = get_logger("Weathervane::Services::PostgresqlKubernetesService");
 	$logger->debug("Configure Postgresql kubernetes");
-	print $dblog "Configure Postgresql Kubernetes\n";
 
 	my $namespace = $self->namespace;	
 	my $configDir        = $self->getParamValue('configDir');

--- a/runHarness/Services/RabbitmqDockerService.pm
+++ b/runHarness/Services/RabbitmqDockerService.pm
@@ -330,7 +330,7 @@ sub setExternalPortNumbers {
 }
 
 sub configure {
-	my ( $self, $logPath, $users, $suffix) = @_;
+	my ( $self, $users, $suffix) = @_;
 
 }
 

--- a/runHarness/Services/RabbitmqKubernetesService.pm
+++ b/runHarness/Services/RabbitmqKubernetesService.pm
@@ -36,10 +36,9 @@ override 'initialize' => sub {
 };
 
 sub configure {
-	my ( $self, $dblog, $serviceType, $users ) = @_;
+	my ( $self, $serviceType, $users ) = @_;
 	my $logger = get_logger("Weathervane::Services::RabbitmqKubernetesService");
 	$logger->debug("Configure Rabbitmq kubernetes");
-	print $dblog "Configure Rabbitmq Kubernetes\n";
 
 	my $namespace = $self->namespace;	
 	my $configDir        = $self->getParamValue('configDir');

--- a/runHarness/Services/Service.pm
+++ b/runHarness/Services/Service.pm
@@ -229,7 +229,7 @@ sub start {
 
 	foreach my $service (@$servicesRef) {
 		$logger->debug( "Configure " . $service->name . "\n" );
-		$service->configure( $logPath, $users, $suffix );
+		$service->configure( $users, $suffix );
 	}
 
 	foreach my $service (@$servicesRef) {

--- a/runHarness/Services/TomcatDockerService.pm
+++ b/runHarness/Services/TomcatDockerService.pm
@@ -302,7 +302,7 @@ sub setExternalPortNumbers {
 }
 
 sub configure {
-	my ( $self, $logPath, $users, $suffix ) = @_;
+	my ( $self, $users, $suffix ) = @_;
 
 }
 

--- a/runHarness/Services/TomcatKubernetesService.pm
+++ b/runHarness/Services/TomcatKubernetesService.pm
@@ -24,10 +24,9 @@ override 'initialize' => sub {
 };
 
 sub configure {
-	my ( $self, $dblog, $serviceType, $users ) = @_;
+	my ( $self, $serviceType, $users ) = @_;
 	my $logger = get_logger("Weathervane::Services::TomcatKubernetesService");
 	$logger->debug("Configure Tomcat kubernetes");
-	print $dblog "Configure Tomcat Kubernetes\n";
 
 	my $namespace = $self->namespace;	
 	my $configDir        = $self->getParamValue('configDir');

--- a/runHarness/Services/ZookeeperKubernetesService.pm
+++ b/runHarness/Services/ZookeeperKubernetesService.pm
@@ -26,10 +26,9 @@ override 'initialize' => sub {
 };
 
 sub configure {
-	my ( $self, $dblog, $serviceType, $users ) = @_;
+	my ( $self, $serviceType, $users ) = @_;
 	my $logger = get_logger("Weathervane::Services::ZookeeperKubernetesService");
 	$logger->debug("Configure Zookeeper kubernetes");
-	print $dblog "Configure Zookeeper Kubernetes\n";
 
 	my $namespace = $self->namespace;	
 	my $configDir        = $self->getParamValue('configDir');

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -1488,11 +1488,11 @@ sub stopRun {
 	my $statsCompleteMsg = {};
 	$statsCompleteMsg->{'timestamp'} = time;
 	my $statsCompleteContent = $self->json->encode($statsCompleteMsg);
-	$url      = $self->getControllerURL() . "/stats/complete/$runName";
+	my $url      = $self->getControllerURL() . "/stats/complete/$runName";
 	my $retryCount = 0;
 	my $success = 0;
 	do {
-		$res = $self->doHttpPost($url, $statsCompleteContent);
+		my $res = $self->doHttpPost($url, $statsCompleteContent);
 		if ( $res->{"is_success"} ) {
 			$success = 1;
 		} else {

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -1484,20 +1484,7 @@ sub stopRun {
 	my $port = $self->portMap->{'http'};
 	my $hostname = $self->host->name;
 
-	# Now send the stop message
-	my $url      = $self->getControllerURL() . "/run/$runName/stop";
-	my $runContent = "{}";
-
-	my $res = $self->doHttpPost($url, $runContent);
-	if ( !$res->{"is_success"} ) {
-		$console_logger->warn(
-			"Could not send stop message to workload driver node on $hostname. Exiting"
-		);
-		return 0;
-	}
-				
-
-	# Now send the stats/complete message the primary driver which is also the statsService host
+	# Send the stats/complete message the primary driver which is also the statsService host
 	my $statsCompleteMsg = {};
 	$statsCompleteMsg->{'timestamp'} = time;
 	my $statsCompleteContent = $self->json->encode($statsCompleteMsg);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
@@ -162,7 +162,7 @@ public class Run {
 		completedWorkloadStati.add(status);
 		if (runningWorkloadNames.isEmpty()) {
 			logger.debug("All workloads have finished.  Run is completed");
-			state = RunState.COMPLETED;
+			this.stop();
 		}
 	}
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Run.java
@@ -158,8 +158,10 @@ public class Run {
 	 * have completed then the run is complete. 
 	 */
 	public void workloadComplete(WorkloadStatus status) {
-		runningWorkloadNames.remove(status.getName());
-		completedWorkloadStati.add(status);
+		synchronized (completedWorkloadStati) {
+			runningWorkloadNames.remove(status.getName());
+			completedWorkloadStati.add(status);			
+		}
 		if (runningWorkloadNames.isEmpty()) {
 			logger.debug("All workloads have finished.  Run is completed");
 			this.stop();
@@ -273,19 +275,20 @@ public class Run {
 		RunStateResponse response = new RunStateResponse();
 		response.setState(getState());
 
-		// Add status for completed workloads
 		List<WorkloadStatus> workloadStati = new ArrayList<WorkloadStatus>();
-		for (WorkloadStatus status : completedWorkloadStati) {
-			workloadStati.add(status);
-		}
-		
-		// Add status for running workloads
-		for (Workload aWorkload: workloads) {
-			if (runningWorkloadNames.contains(aWorkload.getName())) {
-				workloadStati.add(aWorkload.getWorkloadStatus());
+		synchronized (completedWorkloadStati) {
+			// Add status for completed workloads
+			for (WorkloadStatus status : completedWorkloadStati) {
+				workloadStati.add(status);
 			}
-		}
-		
+			
+			// Add status for running workloads
+			for (Workload aWorkload: workloads) {
+				if (runningWorkloadNames.contains(aWorkload.getName())) {
+					workloadStati.add(aWorkload.getWorkloadStatus());
+				}
+			}	
+		}		
 		response.setWorkloadStati(workloadStati);
 
 		return(response);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
@@ -357,7 +357,9 @@ public abstract class Workload implements UserFactory {
 		if (maxUsers < numUsers) {
 			throw new TooManyUsersException("MaxUsers = " + maxUsers);
 		}
-		getLoadPath().changeActiveUsers(numUsers);
+		if (numUsers != this.getNumActiveUsers()) {
+			getLoadPath().changeActiveUsers(numUsers);
+		}
 	}
 
 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/Workload.java
@@ -395,6 +395,7 @@ public abstract class Workload implements UserFactory {
 	
 
 	public void loadPathComplete(WorkloadStatus status) {
+		setState(WorkloadState.COMPLETED);
 		status.setName(name);
 		status.setState(getState());
 		run.workloadComplete(status);

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/LoadPath.java
@@ -176,7 +176,7 @@ public abstract class LoadPath implements Runnable, LoadPathIntervalResultWatche
 		 * Send messages to workloadService on driver nodes indicating new
 		 * number of users to run.
 		 */
-		if (!workload.getState().equals(WorkloadState.COMPLETED)) {
+		if (!workload.getState().equals(WorkloadState.COMPLETED) && (users != numActiveUsers)) {
 			try {
 				changeActiveUsers(users);
 			} catch (Throwable t) {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedFindMaxLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedFindMaxLoadPath.java
@@ -140,7 +140,7 @@ public class SyncedFindMaxLoadPath extends SyncedLoadPath {
 
 	@Override
 	protected IntervalCompleteResult intervalComplete() {
-		logger.info("intervalComplete: " + this.getName());
+		logger.debug("intervalComplete: " + this.getName());
 		statsIntervalComplete = false;
 		if (Phase.INITIALRAMP.equals(curPhase)) {
 			return initialRampIntervalComplete();			
@@ -152,7 +152,7 @@ public class SyncedFindMaxLoadPath extends SyncedLoadPath {
 	@JsonIgnore
 	@Override
 	public UniformLoadInterval getNextIntervalSynced(boolean passed) {
-		logger.info("getNextIntervalSynced: " + this.getName());
+		logger.debug("getNextIntervalSynced: " + this.getName());
 		statsIntervalComplete = false;
 		if (Phase.INITIALRAMP.equals(curPhase)) {
 			curInterval = getNextInitialRampInterval(passed);			
@@ -216,7 +216,7 @@ public class SyncedFindMaxLoadPath extends SyncedLoadPath {
 			result.setPassed(true);			
 		}
 		
-		logger.info("initialRampIntervalComplete " + this.getName() 
+		logger.debug("initialRampIntervalComplete " + this.getName() 
 			+ ": Interval " + phaseIntervalNum + " prevIntervalPassed = "
 			+ prevIntervalPassed);
 		return result;
@@ -729,6 +729,7 @@ public class SyncedFindMaxLoadPath extends SyncedLoadPath {
 	}
 
 	private void loadPathComplete(boolean passed) {
+		logger.info("loadPathComplete for loadPath {}", this.getName());
 		loadPathComplete = true;
 		phaseIntervalNum = 0;
 		WorkloadStatus status = new WorkloadStatus();

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
@@ -4,12 +4,12 @@ SPDX-License-Identifier: BSD-2-Clause
 */
 package com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath;
 
-import java.util.concurrent.TimeUnit;
-
+import java.util.concurrent.TimeUnit;import org.omg.CORBA.COMM_FAILURE;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.vmware.weathervane.workloadDriver.common.core.Workload.WorkloadState;
 import com.vmware.weathervane.workloadDriver.common.core.WorkloadStatus;
 import com.vmware.weathervane.workloadDriver.common.core.loadControl.loadInterval.UniformLoadInterval;
 
@@ -57,7 +57,6 @@ public abstract class SyncedLoadPath extends LoadPath {
 			this.changeInterval(curIntervalNum, result.isPassed());
 			this.startNextInterval();
 		}
-
 	}
 	
 	@Override
@@ -97,11 +96,13 @@ public abstract class SyncedLoadPath extends LoadPath {
 		 * Send messages to workloadService on driver nodes indicating new
 		 * number of users to run.
 		 */
-		try {
-			changeActiveUsers(users);
-		} catch (Throwable t) {
-			logger.warn("changeInterval: LoadPath {} got throwable when notifying hosts of change in active users: {}", 
-							this.getName(), t.getMessage());
+		if (!workload.getState().equals(WorkloadState.COMPLETED)) {
+			try {
+				changeActiveUsers(users);
+			} catch (Throwable t) {
+				logger.warn("changeInterval: LoadPath {} got throwable when notifying hosts of change in active users: {}", 
+						this.getName(), t.getMessage());
+			}
 		}
 	}
 	

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPath/SyncedLoadPath.java
@@ -96,7 +96,7 @@ public abstract class SyncedLoadPath extends LoadPath {
 		 * Send messages to workloadService on driver nodes indicating new
 		 * number of users to run.
 		 */
-		if (!workload.getState().equals(WorkloadState.COMPLETED)) {
+		if (!workload.getState().equals(WorkloadState.COMPLETED) && (users != this.getNumActiveUsers())) {
 			try {
 				changeActiveUsers(users);
 			} catch (Throwable t) {

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -22,7 +22,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 
 	private static final Logger logger = LoggerFactory.getLogger(BaseLoadPathController.class);
 
-	protected Map<String, LoadPathIntervalResultWatcher> watchers = new ConcurrentHashMap<>();
+	protected ConcurrentHashMap<String, LoadPathIntervalResultWatcher> watchers = new ConcurrentHashMap<>();
 	protected List<String> completedWatchers = new ArrayList<>();
 	protected AtomicInteger numWatchers = new AtomicInteger(0);
 	protected Map<Long, Integer> numIntervalResults = new HashMap<>();
@@ -100,11 +100,15 @@ public abstract class BaseLoadPathController implements LoadPathController {
 		 * watchers that completed on the previous interval
 		 */
 		for (String watcherName: completedWatchers) {
+			logger.info("notifyWatchers for interval {}, removing completedWatcher {}", intervalNum, watcherName);
 			watchers.remove(watcherName);
 		}
+		logger.info("notifyWatchers for interval {}, removed completedWatchers.  There are {} remaining watchers", intervalNum, watchers.size());
 		completedWatchers.clear();
 		
 		boolean intervalCombinedResult = intervalCombinedResults.get(intervalNum);
+		logger.info("notifyWatchers for interval {}, intervalCombinedResult = {}", intervalNum, intervalCombinedResult);
+		
 		/*
 		 * Notify the watchers in parallel to avoid waiting for all of the driver nodes 
 		 * to be notified of changes in the number of users.

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -49,7 +49,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 	}
 
 	@Override
-	public void removeIntervalResultCallback(String name) {
+	public synchronized void removeIntervalResultCallback(String name) {
 		logger.debug("removeIntervalResultCallback for loadPath {}", name);
 
 		completedWatchers.add(name);
@@ -101,7 +101,9 @@ public abstract class BaseLoadPathController implements LoadPathController {
 		 */
 		for (String watcherName: completedWatchers) {
 			logger.info("notifyWatchers for interval {}, removing completedWatcher {}", intervalNum, watcherName);
-			watchers.remove(watcherName);
+			if (watcherName != null) {
+				watchers.remove(watcherName);
+			}
 		}
 		logger.info("notifyWatchers for interval {}, removed completedWatchers.  There are {} remaining watchers", intervalNum, watchers.size());
 		completedWatchers.clear();

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -21,6 +21,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 	private static final Logger logger = LoggerFactory.getLogger(BaseLoadPathController.class);
 
 	protected Map<String, LoadPathIntervalResultWatcher> watchers = new HashMap<>();
+	protected List<String> completedWatchers = new ArrayList<>();
 	protected int numWatchers = 0;
 	protected Map<Long, Integer> numIntervalResults = new HashMap<>();
 
@@ -49,7 +50,7 @@ public abstract class BaseLoadPathController implements LoadPathController {
 	public void removeIntervalResultCallback(String name) {
 		logger.debug("removeIntervalResultCallback for loadPath {}", name);
 
-		watchers.remove(name);
+		completedWatchers.add(name);
 		numWatchers--;
 		logger.debug("registerIntervalResultCallback for loadPath {}, numWatchers = {}", 
 				name, numWatchers);
@@ -91,6 +92,16 @@ public abstract class BaseLoadPathController implements LoadPathController {
 	
 	protected void notifyWatchers(long intervalNum) {
 		logger.info("notifyWatchers for interval {}", intervalNum);
+		
+		/*
+		 * Before processing the list of watchers, remove the 
+		 * watchers that completed on the previous interval
+		 */
+		for (String watcherName: completedWatchers) {
+			watchers.remove(watcherName);
+		}
+		completedWatchers.clear();
+		
 		boolean intervalCombinedResult = intervalCombinedResults.get(intervalNum);
 		/*
 		 * Notify the watchers in parallel to avoid waiting for all of the driver nodes 

--- a/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
+++ b/workloadDriver/src/main/java/com/vmware/weathervane/workloadDriver/common/core/loadControl/loadPathController/BaseLoadPathController.java
@@ -49,10 +49,13 @@ public abstract class BaseLoadPathController implements LoadPathController {
 	}
 
 	@Override
-	public synchronized void removeIntervalResultCallback(String name) {
-		logger.debug("removeIntervalResultCallback for loadPath {}", name);
+	public void removeIntervalResultCallback(String name) {
+		logger.info("removeIntervalResultCallback for loadPath {}", name);
 
-		completedWatchers.add(name);
+		synchronized (completedWatchers) {
+			logger.info("removeIntervalResultCallback adding {} to completeWatchers", name);
+			completedWatchers.add(name);			
+		}
 		numWatchers.decrementAndGet();
 		logger.info("removeIntervalResultCallback completed for loadPath {}, numWatchers = {}", 
 				name, numWatchers);

--- a/workloadDriver/src/main/resources/logback.xml
+++ b/workloadDriver/src/main/resources/logback.xml
@@ -16,9 +16,9 @@ SPDX-License-Identifier: BSD-2-Clause
     <logger name="com.vmware" level="WARN" />
     <logger name="com.vmware.weathervane.workloadDriver.common.http" level="WARN" />
     <logger name="com.vmware.weathervane.workloadDriver.common.statistics" level="WARN" />
-    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPathController.BaseLoadPathController" level="INFO" />
-    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath.LoadPath" level="INFO" />
-    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath.SyncedFindMaxLoadPath" level="INFO" />
+    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPathController.BaseLoadPathController" level="WARN" />
+    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath.LoadPath" level="WARN" />
+    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath.SyncedFindMaxLoadPath" level="WARN" />
     <logger name="com.vmware.weathervane.workloadDriver.common.core.Workload" level="WARN" />
 
   <root level="warn">

--- a/workloadDriver/src/main/resources/logback.xml
+++ b/workloadDriver/src/main/resources/logback.xml
@@ -16,7 +16,9 @@ SPDX-License-Identifier: BSD-2-Clause
     <logger name="com.vmware" level="WARN" />
     <logger name="com.vmware.weathervane.workloadDriver.common.http" level="WARN" />
     <logger name="com.vmware.weathervane.workloadDriver.common.statistics" level="WARN" />
-    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl" level="WARN" />
+    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPathController.BaseLoadPathController" level="INFO" />
+    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath.LoadPath" level="INFO" />
+    <logger name="com.vmware.weathervane.workloadDriver.common.core.loadControl.loadPath.SyncedFindMaxLoadPath" level="INFO" />
     <logger name="com.vmware.weathervane.workloadDriver.common.core.Workload" level="WARN" />
 
   <root level="warn">


### PR DESCRIPTION
This pull request has the following changes:

- Fixes hangs due to race conditions introduced when parallelizing operations in the workload driver
- Better log capture for errors occurring when starting data services or loading data
- Adds an option for nodeport and nodeport-internal to only send web traffic to nodes on which a we server is running (`nodeportTargetWeb` parameter).
- Removed some logs files that get created with no or non-useful content
- 