### PR TITLE
Add redeploy command line parameter to all e2e tests to ensure new im…

### DIFF
--- a/testing/e2e/runE2eTests.py
+++ b/testing/e2e/runE2eTests.py
@@ -9,9 +9,9 @@ return_code = 0
 cwd = os.getcwd()
 
 return_code = os.system("touch .accept-weathervane")
-return_code += os.system("./runWeathervane.pl --configFile={}/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.micro".format(cwd))
-return_code += os.system("./runWeathervane.pl --configFile={}/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.xsmall".format(cwd))
-return_code += os.system("./runWeathervane.pl --configFile={}/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.small2".format(cwd))
+return_code += os.system("./runWeathervane.pl --configFile={}/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.micro -- --redeploy".format(cwd))
+return_code += os.system("./runWeathervane.pl --configFile={}/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.xsmall -- --redeploy".format(cwd))
+return_code += os.system("./runWeathervane.pl --configFile={}/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.small2 -- --redeploy".format(cwd))
 
 if return_code > 0:
 	sys.exit(1)


### PR DESCRIPTION
Add --redeploy flag to all test runs to ensure CICD testing uses recently built images.