### PR TITLE
Bhoflich/interval run strategy fix

### DIFF
--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -1319,7 +1319,7 @@ sub startRun {
 								}
 								my $metricsStr;
 								if ($usingIntervalLoadPathType) {
-									$metricsStr = ", Start Users: $startUsersStr, End Users: $endUsersStr, avgRT:$rtStr, percentFailRT: $pctFailRTStr\%";
+									$metricsStr = ", $successStr, Start Users: $startUsersStr, End Users: $endUsersStr, avgRT:$rtStr, percentFailRT: $pctFailRTStr\%";
 								} else {
 									$metricsStr = ", $successStr, throughput:$tptStr, avgRT:$rtStr";									
 								}
@@ -2365,6 +2365,8 @@ sub parseStats {
 			$logger->debug("parseStats: workload " . $appInstanceName 
 					. ", appInstanceNum = " . $appInstanceNum 
 					. " does not have a maxPassInterval");
+			$self->passRT->{$appInstanceNum} = 0;
+			$self->passFailure->{$appInstanceNum} = 0;
 			next;
 		}
 		

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -1319,7 +1319,7 @@ sub startRun {
 								}
 								my $metricsStr;
 								if ($usingIntervalLoadPathType) {
-									$metricsStr = ", $successStr, Start Users: $startUsersStr, End Users: $endUsersStr, avgRT:$rtStr, percentFailRT: $pctFailRTStr\%";
+									$metricsStr = ", Start Users: $startUsersStr, End Users: $endUsersStr, avgRT:$rtStr, percentFailRT: $pctFailRTStr\%, $successStr";
 								} else {
 									$metricsStr = ", $successStr, throughput:$tptStr, avgRT:$rtStr";									
 								}


### PR DESCRIPTION
This fixes an error for uninitialized value $aiPassed... when using the interval runStrategy.
It also adds the successStr into the print message for the same runStrategy, to make them more meaningful.

I am pull requesting this into master because it is a bug fix that does not impact performance.