### PR TITLE
use specific version of cassandra to avoid cqlsh issue in most recent…

### DIFF
--- a/dockerImages/cassandra/Dockerfile
+++ b/dockerImages/cassandra/Dockerfile
@@ -18,7 +18,7 @@ ARG http_proxy
 RUN yum install -y java-1.8.0-openjdk && \
 	yum install -y java-1.8.0-openjdk-devel && \
 	yum install -y python && \
-	yum install -y cassandra && \
+	yum install -y https://archive.apache.org/dist/cassandra/redhat/311x/cassandra-3.11.10-1.noarch.rpm && \
 	yum -y clean all && \
 	mkdir -p /data && \
 	rm /etc/security/limits.d/cassandra.conf && \


### PR DESCRIPTION
… release

The 7/28 release of cassandra 3.11.11-1 broke newly built weathervane cassandra images:

fail messages in console:
Wed Aug 4 18:08:54 2021: Configuring and starting data services for appInstance 1 of workload 1.
Wed Aug 4 18:32:13 2021: Couldn't bring up all data services for appInstance 1 of workload 1.
Wed Aug 4 18:32:14 2021: Couldn't start data services for appInstance 1 of workload 1.

and debug.log:
Traceback (most recent call last):
  File "/usr/bin/cqlsh.py", line 169, in <module>
    from cqlshlib import cql3handling, cqlhandling, pylexotron, sslhandling, cqlshhandling
ImportError: No module named cqlshlib

Others are also seeing issues with cqlsh: https://issues.apache.org/jira/browse/CASSANDRA-16822

This change modifies the dockerfile to use the specific version of cassandra that previously worked. (3.11.10-1)

pull request against master since it is a blocking bug and is not related to performance.