### PR TITLE
Replace package python2-httpie with httpie

### DIFF
--- a/dockerImages/centos7/Dockerfile
+++ b/dockerImages/centos7/Dockerfile
@@ -11,7 +11,7 @@ RUN \
   chmod +x /updateResolveConf.pl && \
   yum -y install wget && \
   yum -y install epel-release && \
-  yum -y install python2-httpie && \
+  yum -y install httpie && \
   yum -y install sudo && \
   yum -y install iproute && \
   yum -y install perl && \


### PR DESCRIPTION
Package python2-httpie, used in the CentOS7 image, is no longer available. Replace with package httpie.
Signed-off-by: Rebecca Yo <griderr@vmware.com>