### PR TITLE
only printing workload number if more than 1 workload

### DIFF
--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -51,10 +51,6 @@ sub startDataManagerContainer {
 
 	my $springProfilesActive = $self->appInstance->getSpringProfilesActive();
 
-	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->workloadDriver->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 	open( FILEIN,  "$configDir/kubernetes/auctionDataManager.yaml" ) or die "$configDir/kubernetes/auctionDataManager.yaml: $!\n";
 	open( FILEOUT, ">/tmp/auctionDataManager-$namespace.yaml" )             or die "Can't open file /tmp/auctionDataManager-$namespace.yaml: $!\n";
 	
@@ -249,7 +245,7 @@ sub prepareData {
 
 	#Setting outputted workloadNum to empty string if only one workload exists
 	my $workloadCount = $self->workloadDriver->{workloadCount};
-	my $outputWorkloadNum = $workloadCount > 1 ? "Workload $workloadNum," : "";
+	my $outputWorkloadNum = $workloadCount > 1 ? "Workload $workloadNum," : "workload";
 
 	$logger->debug("prepareData users = $users, logPath = $logPath");
 	print $logHandle "prepareData users = $users, logPath = $logPath\n";

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -30,10 +30,6 @@ override 'initialize' => sub {
 
 	my $workloadNum = $self->appInstance->workload->instanceNum;
 	my $appInstanceNum = $self->appInstance->instanceNum;
-
-	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->workloadDriver->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 	
 	$self->name("auctiondatamanagerW${workloadNum}A${appInstanceNum}");
 

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -190,7 +190,7 @@ sub prepareDataServices {
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	$console_logger->info(
-		"Configuring and starting data services for appInstance $appInstanceNum of workload $workloadNum.\n" );
+		"Configuring and starting data services for appInstance $appInstanceNum of workload $workloadNum\n" );
 
 	# Start the data services
 	if ($reloadDb) {

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -243,7 +243,8 @@ sub prepareData {
 		return 0;
 	};
 
-	#Setting outputted workloadNum to empty string if only one workload exists
+	# The word 'workload' will only appear if there's more than one workload. 
+	# Otherwise it's omitted because the workload is already implied.
 	my $workloadCount = $self->workloadDriver->{workloadCount};
 	my $outputWorkloadNum = $workloadCount > 1 ? "Workload $workloadNum" : "workload";
 

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -30,6 +30,11 @@ override 'initialize' => sub {
 
 	my $workloadNum = $self->appInstance->workload->instanceNum;
 	my $appInstanceNum = $self->appInstance->instanceNum;
+
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+	
 	$self->name("auctiondatamanagerW${workloadNum}A${appInstanceNum}");
 
 	super();
@@ -49,6 +54,10 @@ sub startDataManagerContainer {
 	my $prepThreads = $self->getParamValue('dbPrepThreads');
 
 	my $springProfilesActive = $self->appInstance->getSpringProfilesActive();
+
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	open( FILEIN,  "$configDir/kubernetes/auctionDataManager.yaml" ) or die "$configDir/kubernetes/auctionDataManager.yaml: $!\n";
 	open( FILEOUT, ">/tmp/auctionDataManager-$namespace.yaml" )             or die "Can't open file /tmp/auctionDataManager-$namespace.yaml: $!\n";

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -190,7 +190,7 @@ sub prepareDataServices {
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	$console_logger->info(
-		"Configuring and starting data services for appInstance $appInstanceNum of workload $workloadNum\n" );
+		"Configuring and starting data services for appInstance $appInstanceNum of workload $workloadNum.\n" );
 
 	# Start the data services
 	if ($reloadDb) {
@@ -245,7 +245,7 @@ sub prepareData {
 
 	#Setting outputted workloadNum to empty string if only one workload exists
 	my $workloadCount = $self->workloadDriver->{workloadCount};
-	my $outputWorkloadNum = $workloadCount > 1 ? "Workload $workloadNum," : "workload";
+	my $outputWorkloadNum = $workloadCount > 1 ? "Workload $workloadNum" : "workload";
 
 	$logger->debug("prepareData users = $users, logPath = $logPath");
 	print $logHandle "prepareData users = $users, logPath = $logPath\n";
@@ -253,7 +253,7 @@ sub prepareData {
 	if (!$self->startDataManagerContainer($users, $logHandle)) {
 		$console_logger->info(
 				    "Could not start AuctionDataManager pod for appInstance "
-				  . "$appInstanceNum of $outputWorkloadNum" );
+				  . "$appInstanceNum of $outputWorkloadNum." );
 		# stop the auctiondatamanager container
 		$self->stopDataManagerContainer($logHandle);
 		return 0;		
@@ -273,7 +273,7 @@ sub prepareData {
 			my $maxUsers = $self->getParamValue('maxUsers');
 			$console_logger->info(
 				    "Data is not loaded for $maxUsers maxUsers for appInstance "
-				  . "$appInstanceNum of $outputWorkloadNum Loading data." );
+				  . "$appInstanceNum of $outputWorkloadNum. Loading data." );
 
 			# Load the data
 			$appInstance->getDataServiceLogFiles($logPath . "/preLoadLogs");
@@ -293,7 +293,7 @@ sub prepareData {
 	}
 
 	$console_logger->info( "Preparing auctions and warming data-services for appInstance "
-				  . "$appInstanceNum of $outputWorkloadNum" );
+				  . "$appInstanceNum of $outputWorkloadNum." );
 	print $logHandle "Exec-ing perl /prepareData.pl in container $name\n";
 	$logger->debug("Exec-ing perl /prepareData.pl  in container $name");
 	my $cluster  = $self->host;	
@@ -315,7 +315,7 @@ sub prepareData {
 		if ($self->getParamValue("reloadOnFailure") && !$ignoreReloadOnFailure) {
 			# Delete the PVCs for this namespace and try again (but only once)
 			$console_logger->info(
-				"Couldn't prepare data services for appInstance $appInstanceNum of $outputWorkloadNum Clearing data and retrying.\n" );
+				"Couldn't prepare data services for appInstance $appInstanceNum of $outputWorkloadNum. Clearing data and retrying.\n" );
 			$appInstance->stopServices("data", $logPath);
 			$cluster->kubernetesDeleteAllWithLabelAndResourceType("app=auction", "pvc", $self->appInstance->namespace );
 			$appInstance->startServices("data", $logPath, 0);

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -32,7 +32,7 @@ override 'initialize' => sub {
 	my $appInstanceNum = $self->appInstance->instanceNum;
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->appInstance->workload->{workloadCount};
+	my $workloadCount = $self->workloadDriver->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 	
 	$self->name("auctiondatamanagerW${workloadNum}A${appInstanceNum}");
@@ -56,7 +56,7 @@ sub startDataManagerContainer {
 	my $springProfilesActive = $self->appInstance->getSpringProfilesActive();
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->appInstance->workload->{workloadCount};
+	my $workloadCount = $self->workloadDriver->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	open( FILEIN,  "$configDir/kubernetes/auctionDataManager.yaml" ) or die "$configDir/kubernetes/auctionDataManager.yaml: $!\n";
@@ -194,7 +194,7 @@ sub prepareDataServices {
 	my $appInstanceNum = $self->appInstance->instanceNum;
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->appInstance->workload->{workloadCount};
+	my $workloadCount = $self->workloadDriver->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	$console_logger->info(
@@ -243,7 +243,7 @@ sub prepareData {
 	my $retVal         = 0;
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->appInstance->workload->{workloadCount};
+	my $workloadCount = $self->workloadDriver->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	my $time = `date +%H.%M`;
@@ -371,7 +371,7 @@ sub loadData {
 	my $namespace = $self->appInstance->namespace;
 	
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->appInstance->workload->{workloadCount};
+	my $workloadCount = $self->workloadDriver->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	$logger->debug("loadData for workload $workloadNum, appInstance $appInstanceNum");
@@ -467,7 +467,7 @@ sub isDataLoaded {
 	my $appInstanceNum = $self->appInstance->instanceNum;
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->appInstance->workload->{workloadCount};
+	my $workloadCount = $self->workloadDriver->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	$logger->debug("isDataLoaded for workload $workloadNum, appInstance $appInstanceNum");

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -32,7 +32,7 @@ override 'initialize' => sub {
 	my $appInstanceNum = $self->appInstance->instanceNum;
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->{workloadCount};
+	my $workloadCount = $self->appInstance->workload->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 	
 	$self->name("auctiondatamanagerW${workloadNum}A${appInstanceNum}");
@@ -56,7 +56,7 @@ sub startDataManagerContainer {
 	my $springProfilesActive = $self->appInstance->getSpringProfilesActive();
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->{workloadCount};
+	my $workloadCount = $self->appInstance->workload->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	open( FILEIN,  "$configDir/kubernetes/auctionDataManager.yaml" ) or die "$configDir/kubernetes/auctionDataManager.yaml: $!\n";
@@ -194,7 +194,7 @@ sub prepareDataServices {
 	my $appInstanceNum = $self->appInstance->instanceNum;
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->{workloadCount};
+	my $workloadCount = $self->appInstance->workload->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	$console_logger->info(
@@ -243,7 +243,7 @@ sub prepareData {
 	my $retVal         = 0;
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->{workloadCount};
+	my $workloadCount = $self->appInstance->workload->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	my $time = `date +%H.%M`;
@@ -371,7 +371,7 @@ sub loadData {
 	my $namespace = $self->appInstance->namespace;
 	
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->{workloadCount};
+	my $workloadCount = $self->appInstance->workload->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	$logger->debug("loadData for workload $workloadNum, appInstance $appInstanceNum");
@@ -467,7 +467,7 @@ sub isDataLoaded {
 	my $appInstanceNum = $self->appInstance->instanceNum;
 
 	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->{workloadCount};
+	my $workloadCount = $self->appInstance->workload->{workloadCount};
 	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	$logger->debug("isDataLoaded for workload $workloadNum, appInstance $appInstanceNum");

--- a/runHarness/DataManagers/AuctionKubernetesDataManager.pm
+++ b/runHarness/DataManagers/AuctionKubernetesDataManager.pm
@@ -184,6 +184,10 @@ sub prepareDataServices {
 	my $workloadNum    = $self->appInstance->workload->instanceNum;
 	my $appInstanceNum = $self->appInstance->instanceNum;
 
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	$console_logger->info(
 		"Configuring and starting data services for appInstance $appInstanceNum of workload $workloadNum.\n" );
 
@@ -228,6 +232,10 @@ sub prepareData {
 	my $reloadDb       = $self->getParamValue('reloadDb');
 	my $appInstance    = $self->appInstance;
 	my $retVal         = 0;
+
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	my $time = `date +%H.%M`;
 	chomp($time);
@@ -353,6 +361,10 @@ sub loadData {
 	my $logName          = "$logPath/loadData-W${workloadNum}I${appInstanceNum}-$time.log";
 	my $namespace = $self->appInstance->namespace;
 	
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	$logger->debug("loadData for workload $workloadNum, appInstance $appInstanceNum");
 
 	my $applog;
@@ -444,6 +456,11 @@ sub isDataLoaded {
 	my $namespace = $self->appInstance->namespace;
 	my $workloadNum    = $self->appInstance->workload->instanceNum;
 	my $appInstanceNum = $self->appInstance->instanceNum;
+
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	$logger->debug("isDataLoaded for workload $workloadNum, appInstance $appInstanceNum");
 
 

--- a/runHarness/Factories/WorkloadDriverFactory.pm
+++ b/runHarness/Factories/WorkloadDriverFactory.pm
@@ -15,7 +15,7 @@ use namespace::autoclean;
 with Storage( 'format' => 'JSON', 'io' => 'File' );
 
 sub getWorkloadDriver {
-	my ( $self, $workloadDriverHashRef, $host ) = @_;
+	my ( $self, $workloadDriverHashRef, $host, $numWorkloads ) = @_;
 	
 	my $hostType = ref $host;
 	my $workloadType = $workloadDriverHashRef->{"workloadImpl"};
@@ -39,7 +39,7 @@ sub getWorkloadDriver {
 	else {
 		die "No matching workloadDriver for workload type $workloadType";
 	}
-
+	$workloadDriver->workloadCount($numWorkloads);
 	return $workloadDriver;
 }
 

--- a/runHarness/Workload/Workload.pm
+++ b/runHarness/Workload/Workload.pm
@@ -864,6 +864,10 @@ sub writeUsersTxt {
 	my $appInstancesRef = $self->appInstancesRef;
 
 	my $workloadNum = $self->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->primaryDriver->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 	
 	foreach my $appInstance (@$appInstancesRef) {
 		my $instanceNum = $appInstance->instanceNum;

--- a/runHarness/Workload/Workload.pm
+++ b/runHarness/Workload/Workload.pm
@@ -867,7 +867,7 @@ sub writeUsersTxt {
 
 	#Setting outputted workloadNum to nothing if only one workload exists
 	my $workloadCount = $self->primaryDriver->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+	my $outputWorkloadNum = $workloadCount > 1 ? "Workload $workloadNum," : "";
 	
 	foreach my $appInstance (@$appInstancesRef) {
 		my $instanceNum = $appInstance->instanceNum;
@@ -875,12 +875,12 @@ sub writeUsersTxt {
 		if ($loadPathType eq 'fixed') {
 			my $users = $appInstance->users;
 			if ($users) {
-				my $outString      = "Workload $workloadNum, App Instance $instanceNum: $users Users";
+				my $outString      = "$outputWorkloadNum App Instance $instanceNum: $users Users";
 				$console_logger->info($outString);
 				print $fileOut "$outString\n";
 			}
 		} elsif ($loadPathType eq 'findMax') {
-				my $outString      = "Workload $workloadNum, App Instance $instanceNum: FindMax";
+				my $outString      = "$outputWorkloadNum App Instance $instanceNum: FindMax";
 				$console_logger->info($outString);
 				print $fileOut "$outString\n";			
 		}

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -173,6 +173,11 @@ override 'initialize' => sub {
 	super();
 	my $workloadNum = $self->workload->instanceNum;
 	my $instanceNum = $self->instanceNum;
+
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	$self->name("driverW${workloadNum}I${instanceNum}");
 	$self->json(JSON->new);
 	$self->json->relaxed(1);

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -590,7 +590,7 @@ override 'configure' => sub {
 
 	#Setting outputted workloadNum to empty string if only one workload exists
 	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+	my $outputWorkloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	$logger->debug("configure for workload $workloadNum, suffix = $suffix");
 	$self->suffix($suffix);
@@ -615,7 +615,7 @@ override 'configure' => sub {
 	my $rtPassingPct = $self->getParamValue('responseTimePassingPercentile');
 	if ( ( $rtPassingPct < 0 ) || ( $rtPassingPct > 100 ) ) {
 		$console_logger->error(
-"The responseTimePassingPercentile for workload $workloadNum must be between 0.0 and 100.0"
+"The responseTimePassingPercentile for workload $outputWorkloadNum must be between 0.0 and 100.0"
 		);
 		exit -1;
 	}
@@ -684,10 +684,6 @@ sub killOld {
 	my $logger           = get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum    = $self->workload->instanceNum;
 	my $console_logger = get_logger("Console");
-
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	my $logName = "$setupLogDir/killOld$workloadNum.log";
 	my $logHandle;
@@ -791,10 +787,6 @@ sub startAuctionWorkloadDriverContainer {
 	my $logger         = get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum    = $driver->workload->instanceNum;
 	my $name        = $driver->name;
-
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 		
 	$driver->host->dockerStopAndRemove( $applog, $name );
 
@@ -925,9 +917,9 @@ sub initializeRun {
 	my $port = $self->portMap->{'http'};
 	my $workloadNum    = $self->workload->instanceNum;
 
-	#Setting outputted workloadNum to nothing if only one workload exists
+	#Setting outputted workloadNum to empty string if only one workload exists
 	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+	my $outputWorkloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	my $runName = "runW${workloadNum}";
 
@@ -956,7 +948,7 @@ sub initializeRun {
 
 	if ( !$isUp ) {
 		$console_logger->warn(
-"The workload controller for workload $workloadNum did not start within 10 minutes. Exiting"
+"The workload controller for workload $outputWorkloadNum did not start within 10 minutes. Exiting"
 		);
 		return 0;
 	} else {
@@ -1005,7 +997,7 @@ sub initializeRun {
 
 	if ( !$isUp ) {
 		$console_logger->warn(
-"The workload driver nodes for workload $workloadNum did not start within 10 minutes. Exiting"
+"The workload driver nodes for workload $outputWorkloadNum did not start within 10 minutes. Exiting"
 		);
 		return 0;
 	} else {
@@ -1109,9 +1101,9 @@ sub startRun {
 	my $driverJvmOpts           = $self->getParamValue('driverJvmOpts');
 	my $workloadNum             = $self->workload->instanceNum;
 
-	#Setting outputted workloadNum to nothing if only one workload exists
+	#Setting outputted workloadNum to empty string if only one workload exists
 	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+	my $outputWorkloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	my $runName                 = "runW${workloadNum}";
 	my $rampUp              = $self->getParamValue('rampUp');
@@ -1254,7 +1246,7 @@ sub startRun {
 
 					if ($usingFixedLoadPathType) {
 						$console_logger->info(
-							"Running Workload $workloadNum: $impl.  Run will finish in approximately $runLengthMinutes minutes."
+							"Running Workload $outputWorkloadNum: $impl.  Run will finish in approximately $runLengthMinutes minutes."
 						);
 						$logger->debug("Workload will ramp up for $rampUp. suffix = $suffix");
 					}
@@ -1358,7 +1350,7 @@ sub startRun {
 								} else {
 									$metricsStr = ", $successStr, throughput:$tptStr, avgRT:$rtStr";									
 								}
-								$console_logger->info("   [workload $workloadNum, appInstance: $appInstanceNum] Ended: $nameStr${metricsStr}.");
+								$console_logger->info("   [workload $outputWorkloadNum, appInstance: $appInstanceNum] Ended: $nameStr${metricsStr}.");
 							}
 						}
 					}
@@ -1405,7 +1397,7 @@ sub startRun {
             # Now print the messages for the start of the next interval
             my $numAppInstances = $#{$workloadStati} + 1;
             foreach my $nameStr (keys %nameStringToInstances) {
-            	my $instancesString = "[workload $workloadNum, appInstance";
+            	my $instancesString = "[workload $outputWorkloadNum, appInstance";
             	my $instancesListRef = $nameStringToInstances{$nameStr};
             	if ($#{$instancesListRef} == 0) {
             		$instancesString .= ": " . $instancesListRef->[0];
@@ -1432,7 +1424,7 @@ sub startRun {
 		}
 		sleep 60;
 	}
-	$console_logger->info("workload $workloadNum: Run is complete");
+	$console_logger->info("workload $outputWorkloadNum: Run is complete");
 	kill(9, $pid);
 	
 	my $destinationPath = $logDir . "/statistics/workloadDriver";
@@ -1476,7 +1468,7 @@ sub startRun {
 	close $logHandle;
 
 	my $impl = $self->getParamValue('workloadImpl');
-	$console_logger->info("Workload $workloadNum finished");
+	$console_logger->info("Workload $OutputWorkloadNum finished");
 
 	return 1;
 }
@@ -1518,10 +1510,6 @@ sub stopRun {
 
 	my $workloadNum             = $self->workload->instanceNum;
 
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 	my $runName                 = "runW${workloadNum}";
 	my $port = $self->portMap->{'http'};
 	my $hostname = $self->host->name;
@@ -1558,10 +1546,6 @@ sub shutdownDrivers {
 
 	my $workloadNum             = $self->workload->instanceNum;
 
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 	my $runName                 = "runW${workloadNum}";
 	my $port = $self->portMap->{'http'};
 	my $hostname = $self->host->name;
@@ -1596,11 +1580,6 @@ sub isUp {
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum = $self->workload->instanceNum;
-
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-	
 	my $runName     = "runW${workloadNum}";
 
 	my $controllerUrl = $self->getControllerURL();
@@ -1621,11 +1600,6 @@ sub areDriversUp {
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum = $self->workload->instanceNum;
-
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 	my $runName     = "runW${workloadNum}";
 
 	my $controllerUrl = $self->getControllerURL();
@@ -1821,10 +1795,6 @@ sub startStatsCollection {
 	my ( $self, $intervalLengthSec, $numIntervals ) = @_;
 	my $workloadNum = $self->workload->instanceNum;
 
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 # ToDo: Add a script to the docker image to do this:
 #	my $hostname = $self->host->name;
 #	`cp /tmp/gc-W${workloadNum}.log /tmp/gc-W${workloadNum}_rampup.log 2>&1`;
@@ -1842,10 +1812,6 @@ sub getStatsFiles {
 	my $hostname           = $self->host->name;
 	my $destinationPath  = $baseDestinationPath . "/" . $hostname;
 	my $workloadNum      = $self->workload->instanceNum;
-
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	my $name               = $self->name;
 		
@@ -2130,10 +2096,6 @@ sub getStatsSummary {
 	if ( -f "$gcviewerDir/gcviewer-1.34-SNAPSHOT.jar" ) {
 		my $workloadNum = $self->workload->instanceNum;
 
-		#Setting outputted workloadNum to nothing if only one workload exists
-		my $workloadCount = $self->{workloadCount};
-		$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 		open( HOSTCSVFILE,
 ">>$statsLogPath/workload${workloadNum}_workloadDriver_gc_summary.csv"
 		  )
@@ -2230,11 +2192,6 @@ sub getNumActiveUsers {
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum = $self->workload->instanceNum;
-
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 	my $runName     = "runW${workloadNum}";
 
 	my %appInstanceToUsersHash;
@@ -2285,11 +2242,6 @@ sub setNumActiveUsers {
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum = $self->workload->instanceNum;
-
-	#Setting outputted workloadNum to nothing if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 	my $runName     = "runW${workloadNum}";
 
 	my %appInstanceToUsersHash;
@@ -2360,9 +2312,9 @@ sub parseStats {
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum             = $self->workload->instanceNum;
 
-	#Setting outputted workloadNum to nothing if only one workload exists
+	#Setting outputted workloadNum to empty string if only one workload exists
 	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+	my $outputWorkloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	my $runName                 = "runW${workloadNum}";
 	my $hostname = $self->host->name;
@@ -2402,7 +2354,7 @@ sub parseStats {
 	if ( $res->{"is_success"} ) {
 		$runStatus = $self->json->decode( $res->{"content"} );			
 	} else {
-		$console_logger->warn("Could not retrieve final run state for workload $workloadNum");
+		$console_logger->warn("Could not retrieve final run state for workload $outputWorkloadNum");
 		return 0;
 	}
 
@@ -2441,7 +2393,7 @@ sub parseStats {
 								. "\nIncrease maxUsers and try again.";				
 			}
 		}
-		$console_logger->info("Workload $workloadNum, appInstance $appInstanceName: $resultString");
+		$console_logger->info("Workload $outputWorkloadNum, appInstance $appInstanceName: $resultString");
 		
 		my $maxPassIntervalName = $workloadStatus->{"maxPassIntervalName"};
 		$logger->debug("parseStats: Parsing workloadStatus for workload " . $appInstanceName 
@@ -2484,7 +2436,7 @@ sub parseStats {
 		if ( $res->{"is_success"} ) {
 			$statsSummaryRollup = $self->json->decode( $res->{"content"} )->{'statsSummaryRollup'};			
 		} else {
-			$console_logger->warn("Could not retrieve max passing interval summary for workload $workloadNum");
+			$console_logger->warn("Could not retrieve max passing interval summary for workload $outputWorkloadNum");
 			return 0;
 		}
 		

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -1468,7 +1468,7 @@ sub startRun {
 	close $logHandle;
 
 	my $impl = $self->getParamValue('workloadImpl');
-	$console_logger->info("Workload $OutputWorkloadNum finished");
+	$console_logger->info("Workload $outputWorkloadNum finished");
 
 	return 1;
 }

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -174,8 +174,6 @@ override 'initialize' => sub {
 	my $workloadNum = $self->workload->instanceNum;
 	my $instanceNum = $self->instanceNum;
 	$self->name("driverW${workloadNum}I${instanceNum}");
-	my $TEST = $self->{workloadCount}; 							# DELETE
-	print "Testing within AuctionWorkloadDriver init: $TEST";	# DELETE
 	$self->json(JSON->new);
 	$self->json->relaxed(1);
 	$self->json->pretty(1);
@@ -197,6 +195,11 @@ sub checkConfig {
 	my ($self) = @_;
 	my $console_logger = get_logger("Console");
 	my $workloadNum    = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	
 	# Validate the the CPU and Mem sizings are in valid Kubernetes format
 	my @drivers =  @{ $self->secondaries };
@@ -373,6 +376,10 @@ sub createRunConfigHash {
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $console_logger = get_logger("Console");
 	my $workloadNum    = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 
 	my $rampUp           = $self->getParamValue('rampUp');
 	my $warmUp           = $self->getParamValue('warmUp');
@@ -580,6 +587,11 @@ override 'configure' => sub {
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $console_logger = get_logger("Console");
 	my $workloadNum    = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	$logger->debug("configure for workload $workloadNum, suffix = $suffix");
 	$self->suffix($suffix);
 	$self->appInstances($appInstancesRef);
@@ -673,6 +685,10 @@ sub killOld {
 	my $workloadNum    = $self->workload->instanceNum;
 	my $console_logger = get_logger("Console");
 
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $logName = "$setupLogDir/killOld$workloadNum.log";
 	my $logHandle;
 	open( $logHandle, ">$logName" ) or do {
@@ -746,6 +762,10 @@ sub startDrivers {
 	my $workloadNum    = $self->workload->instanceNum;
 	$logger->debug("Starting workload driver containers");
 
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	# Start the driver on all of the secondaries
 	my $secondariesRef = $self->secondaries;
 	foreach my $secondary (@$secondariesRef) {
@@ -771,6 +791,10 @@ sub startAuctionWorkloadDriverContainer {
 	my $logger         = get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum    = $driver->workload->instanceNum;
 	my $name        = $driver->name;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 		
 	$driver->host->dockerStopAndRemove( $applog, $name );
 
@@ -899,7 +923,12 @@ sub initializeRun {
 	my $logger         = get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	$self->suffix($suffix);
 	my $port = $self->portMap->{'http'};
-	my $workloadNum    = $self->workload->instanceNum; # TODO: Change to undef if workloadcount is 1
+	my $workloadNum    = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $runName = "runW${workloadNum}";
 
 	my $logName = "$logDir/InitializeRun$suffix.log";
@@ -1079,6 +1108,11 @@ sub startRun {
 	  
 	my $driverJvmOpts           = $self->getParamValue('driverJvmOpts');
 	my $workloadNum             = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $runName                 = "runW${workloadNum}";
 	my $rampUp              = $self->getParamValue('rampUp');
 	my $warmUp              = $self->getParamValue('warmUp');
@@ -1483,6 +1517,11 @@ sub stopRun {
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 
 	my $workloadNum             = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $runName                 = "runW${workloadNum}";
 	my $port = $self->portMap->{'http'};
 	my $hostname = $self->host->name;
@@ -1518,6 +1557,11 @@ sub shutdownDrivers {
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 
 	my $workloadNum             = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $runName                 = "runW${workloadNum}";
 	my $port = $self->portMap->{'http'};
 	my $hostname = $self->host->name;
@@ -1552,6 +1596,11 @@ sub isUp {
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+	
 	my $runName     = "runW${workloadNum}";
 
 	my $controllerUrl = $self->getControllerURL();
@@ -1572,6 +1621,11 @@ sub areDriversUp {
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $runName     = "runW${workloadNum}";
 
 	my $controllerUrl = $self->getControllerURL();
@@ -1766,6 +1820,11 @@ sub stopStatsCollection {
 sub startStatsCollection {
 	my ( $self, $intervalLengthSec, $numIntervals ) = @_;
 	my $workloadNum = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 # ToDo: Add a script to the docker image to do this:
 #	my $hostname = $self->host->name;
 #	`cp /tmp/gc-W${workloadNum}.log /tmp/gc-W${workloadNum}_rampup.log 2>&1`;
@@ -1783,6 +1842,11 @@ sub getStatsFiles {
 	my $hostname           = $self->host->name;
 	my $destinationPath  = $baseDestinationPath . "/" . $hostname;
 	my $workloadNum      = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $name               = $self->name;
 		
 	if ( !( -e $destinationPath ) ) {
@@ -2065,6 +2129,11 @@ sub getStatsSummary {
 	# Only parseGc if gcviewer is present
 	if ( -f "$gcviewerDir/gcviewer-1.34-SNAPSHOT.jar" ) {
 		my $workloadNum = $self->workload->instanceNum;
+
+		#Setting outputted workloadNum to nothing if only one workload exists
+		my $workloadCount = $self->{workloadCount};
+		$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 		open( HOSTCSVFILE,
 ">>$statsLogPath/workload${workloadNum}_workloadDriver_gc_summary.csv"
 		  )
@@ -2161,6 +2230,11 @@ sub getNumActiveUsers {
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $runName     = "runW${workloadNum}";
 
 	my %appInstanceToUsersHash;
@@ -2211,6 +2285,11 @@ sub setNumActiveUsers {
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $runName     = "runW${workloadNum}";
 
 	my %appInstanceToUsersHash;
@@ -2280,6 +2359,11 @@ sub parseStats {
 	my $logger =
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $workloadNum             = $self->workload->instanceNum;
+
+	#Setting outputted workloadNum to nothing if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
+
 	my $runName                 = "runW${workloadNum}";
 	my $hostname = $self->host->name;
 

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -174,10 +174,6 @@ override 'initialize' => sub {
 	my $workloadNum = $self->workload->instanceNum;
 	my $instanceNum = $self->instanceNum;
 
-	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 	$self->name("driverW${workloadNum}I${instanceNum}");
 	$self->json(JSON->new);
 	$self->json->relaxed(1);
@@ -381,11 +377,6 @@ sub createRunConfigHash {
 	  get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	my $console_logger = get_logger("Console");
 	my $workloadNum    = $self->workload->instanceNum;
-
-	#Setting outputted workloadNum to empty string if only one workload exists
-	my $workloadCount = $self->{workloadCount};
-	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
-
 	my $rampUp           = $self->getParamValue('rampUp');
 	my $warmUp           = $self->getParamValue('warmUp');
 	my $rampDown         = $self->getParamValue('rampDown');
@@ -428,6 +419,10 @@ sub createRunConfigHash {
 
 	my $numAppInstances = $#{$appInstancesRef} + 1;
 	my $maxPassHint = ceil($self->getParamValue('maxPassHint') / $numAppInstances);
+
+	#Setting outputted workloadNum to empty string if only one workload exists
+	my $workloadCount = $self->{workloadCount};
+	$workloadNum = $workloadCount > 1 ? $workloadNum : "";
 	
 	foreach my $appInstance (@$appInstancesRef) {
 		my $instanceNum = $appInstance->instanceNum;

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -174,7 +174,8 @@ override 'initialize' => sub {
 	my $workloadNum = $self->workload->instanceNum;
 	my $instanceNum = $self->instanceNum;
 	$self->name("driverW${workloadNum}I${instanceNum}");
-	
+	my $TEST = $self->{workloadCount}; 							# DELETE
+	print "Testing within AuctionWorkloadDriver init: $TEST";	# DELETE
 	$self->json(JSON->new);
 	$self->json->relaxed(1);
 	$self->json->pretty(1);
@@ -898,7 +899,7 @@ sub initializeRun {
 	my $logger         = get_logger("Weathervane::WorkloadDrivers::AuctionWorkloadDriver");
 	$self->suffix($suffix);
 	my $port = $self->portMap->{'http'};
-	my $workloadNum    = $self->workload->instanceNum;
+	my $workloadNum    = $self->workload->instanceNum; # TODO: Change to undef if workloadcount is 1
 	my $runName = "runW${workloadNum}";
 
 	my $logName = "$logDir/InitializeRun$suffix.log";

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -1437,7 +1437,7 @@ sub startRun {
 		}
 		sleep 60;
 	}
-	$console_logger->info("workload: $workloadNum: Run is complete");
+	$console_logger->info("workload $workloadNum: Run is complete");
 	kill(9, $pid);
 	
 	my $destinationPath = $logDir . "/statistics/workloadDriver";

--- a/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/AuctionWorkloadDriver.pm
@@ -1267,6 +1267,7 @@ sub startRun {
 	my @curIntervalNames;
 	my @lastIntervalNames;
 	my @statsRunning;
+	my $tempOutputWorkloadNum = $workloadCount > 1 ? "Workload $workloadNum," : "";
 
 	sleep 30; #initial sleep before getting state
 	while (!$runCompleted) {
@@ -1350,7 +1351,7 @@ sub startRun {
 								} else {
 									$metricsStr = ", $successStr, throughput:$tptStr, avgRT:$rtStr";									
 								}
-								$console_logger->info("   [workload $outputWorkloadNum, appInstance: $appInstanceNum] Ended: $nameStr${metricsStr}.");
+								$console_logger->info("   [$tempOutputWorkloadNum appInstance: $appInstanceNum] Ended: $nameStr${metricsStr}.");
 							}
 						}
 					}
@@ -1397,7 +1398,7 @@ sub startRun {
             # Now print the messages for the start of the next interval
             my $numAppInstances = $#{$workloadStati} + 1;
             foreach my $nameStr (keys %nameStringToInstances) {
-            	my $instancesString = "[workload $outputWorkloadNum, appInstance";
+            	my $instancesString = "[$tempOutputWorkloadNum appInstance";
             	my $instancesListRef = $nameStringToInstances{$nameStr};
             	if ($#{$instancesListRef} == 0) {
             		$instancesString .= ": " . $instancesListRef->[0];

--- a/runHarness/WorkloadDrivers/WorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/WorkloadDriver.pm
@@ -31,6 +31,12 @@ has 'workload' => (
 	isa => 'Workload',
 );
 
+has 'workloadCount' => (
+	is  => 'rw',
+	isa => 'Num',
+	default => 0,
+);
+
 class_has 'nextPortMultiplierByHostName' => (
 	is      => 'rw',
 	isa     => 'HashRef[Int]',

--- a/runHarness/WorkloadDrivers/WorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/WorkloadDriver.pm
@@ -95,6 +95,12 @@ sub setWorkload {
 	$self->workload($workload);
 }
 
+sub workloadCount {
+	my ($self, $count) = @_;
+	$self->{workloadCount} = $count;
+	return $self->{workloadCount};
+}
+
 sub checkConfig {
 	my ($self) = @_;
 	my $console_logger = get_logger("Console");

--- a/runHarness/WorkloadDrivers/WorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/WorkloadDriver.pm
@@ -95,11 +95,6 @@ sub setWorkload {
 	$self->workload($workload);
 }
 
-sub setWorkloadCount {
-	my ($self, $count) = @_;
-	$self->workloadCount($count);
-}
-
 sub checkConfig {
 	my ($self) = @_;
 	my $console_logger = get_logger("Console");

--- a/runHarness/WorkloadDrivers/WorkloadDriver.pm
+++ b/runHarness/WorkloadDrivers/WorkloadDriver.pm
@@ -95,10 +95,9 @@ sub setWorkload {
 	$self->workload($workload);
 }
 
-sub workloadCount {
+sub setWorkloadCount {
 	my ($self, $count) = @_;
-	$self->{workloadCount} = $count;
-	return $self->{workloadCount};
+	$self->workloadCount($count);
 }
 
 sub checkConfig {

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -653,18 +653,21 @@ if ( $logger->is_debug() ) {
 		$logger->debug($tmp);
 	}
 }
-$console_logger->info("Run Configuration has $numWorkloads workloads.");
+$console_logger->info("Run Configuration has $numWorkloads workload(s).");
 
 # Create the workload instances and all of their sub-parts
 my $workloadNum = 1;
 my @workloads;
 foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
+	$workloadParamHashRef->{workloadCount} = $numWorkloads;
+	my $outputWorkloadNum = ($numWorkloads == 1 ? undef : $workloadNum);
+	
 	my $configSize = $workloadParamHashRef->{'configurationSize'};
 	# Check that the configurationSize is one of those allowed for this workload
 	my $workloadImpl = $workloadParamHashRef->{'workloadImpl'};
 	my $validSizesRef = $WeathervaneTypes::appInstanceSizes{$workloadImpl};
 	if (!($configSize ~~  @$validSizesRef)) {
-			$console_logger->error("Error: For workload " . $workloadNum . ", "
+			$console_logger->error("Error: For workload " . $outputWorkloadNum . ", "
 				. $configSize . " is not a valid configurationSize.  Valid sizes are: @$validSizesRef");
 			exit(1);		
 	}
@@ -672,7 +675,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 	if ($configSize ne "custom") {
 		my @configKeys = keys $fixedConfigs;
 		if (!($configSize ~~ @configKeys)) {
-			$console_logger->error("Error: For workload " . $workloadNum 
+			$console_logger->error("Error: For workload " . $outputWorkloadNum 
 				.  " configurationSize " . $configSize . " does not exist.");
 			exit(1);
 		}
@@ -720,7 +723,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 	
 	my $numAppInstances = $#{$appInstanceParamHashRefs} + 1;
 	if ( $logger->is_debug() ) {
-		$logger->debug("For workload $workloadNum, have $numAppInstances appInstances");
+		$logger->debug("For workload $outputWorkloadNum, have $numAppInstances appInstances");
 		#$logger->debug("Their Param hash refs are:");
 		#foreach my $paramHashRef (@$appInstanceParamHashRefs) {
 		#	my $tmp = $json->encode($paramHashRef);
@@ -746,7 +749,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 	
 	if ( $#$driversParamHashRefs < 0 ) {
 		$console_logger->error(
-"Workload $workloadNum does not have any drivers.  Specify at least one workload driver using either the numDrivers or drivers parameters."
+"Workload $outputWorkloadNum does not have any drivers.  Specify at least one workload driver using either the numDrivers or drivers parameters."
 		);
 		exit(-1);
 	}
@@ -757,7 +760,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 	
 	if ( $logger->is_debug() ) {
 		my $tmp = $json->encode($primaryDriverParamHashRef);
-		$logger->debug( "For workload $workloadNum, the primary driver instance paramHashRef is:\n" . $tmp );
+		$logger->debug( "For workload $outputWorkloadNum, the primary driver instance paramHashRef is:\n" . $tmp );
 	}
 
 	# Create the primary workload driver
@@ -778,7 +781,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 
 	my $numSecondaries = $#{$driversParamHashRefs} + 1;
 	if ( $logger->is_debug() ) {
-		$logger->debug("For workload $workloadNum, have $numSecondaries secondary drivers");
+		$logger->debug("For workload $outputWorkloadNum, have $numSecondaries secondary drivers");
 		#$logger->debug("Their Param hash refs are:");
 		#foreach my $paramHashRef (@$driversParamHashRefs) {
 		#	my $tmp = $json->encode($paramHashRef);
@@ -787,7 +790,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 	}
 
 	my $numDrivers = $numSecondaries + 1;
-	$console_logger->info("Workload $workloadNum has $numDrivers workload-driver nodes");
+	$console_logger->info("Workload $outputWorkloadNum has $numDrivers workload-driver nodes");
 
 	# Create the secondary drivers and add them to the primary driver
 	foreach my $secondaryDriverParamHashRef (@$driversParamHashRefs) {
@@ -829,7 +832,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 		}
 	}
 	if ($allAiSameConfig && ($commonConfigSize ne "custom")) {
-		$console_logger->info("Workload $workloadNum has $numAppInstances $commonConfigSize application instances:");
+		$console_logger->info("Workload $outputWorkloadNum has $numAppInstances $commonConfigSize application instances:");
 		my $appInstanceParamHashRef = $appInstanceParamHashRefs->[0];
 		my $serviceTypesRef = $WeathervaneTypes::serviceTypes{$workloadImpl};
 		foreach my $serviceType (@$serviceTypesRef) {
@@ -838,7 +841,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 			$console_logger->info( "\t$numScvInstances " . ucfirst($serviceType) . "s" );
 		}		
 	} else {
-		$console_logger->info("Workload $workloadNum has $numAppInstances application instances.");
+		$console_logger->info("Workload $outputWorkloadNum has $numAppInstances application instances.");
 	}
 
 	# Create the appInstances and add them to the workload
@@ -846,7 +849,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 	my $appInstanceNum = 1;    # Count appInstances so that each gets a unique suffix
 	foreach my $appInstanceParamHashRef (@$appInstanceParamHashRefs) {
 		if (!$allAiSameConfig || ($commonConfigSize eq "custom")) {
-			$console_logger->info("Workload $workloadNum, Application Instance $appInstanceNum configuration:");
+			$console_logger->info("Workload $outputWorkloadNum, Application Instance $appInstanceNum configuration:");
 		}
 		
 		my $users = shift @usersList;
@@ -905,7 +908,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 			my $numScvInstances = $#{$svcInstanceParamHashRefs} + 1;
 			if ( $logger->is_debug() ) {
 				$logger->debug(
-					"For workload $workloadNum and appInstance $appInstanceNum, have $numScvInstances ${serviceType}s."
+					"For workload $outputWorkloadNum and appInstance $appInstanceNum, have $numScvInstances ${serviceType}s."
 				);
 				#$logger->debug("Their Param hash refs are:");
 				#foreach my $paramHashRef (@$svcInstanceParamHashRefs) {
@@ -942,7 +945,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 		# This may affect the configuration of port numbers
 		my $edgeService = $appInstance->getEdgeService();
 		$weathervane_logger->debug(
-			"EdgeService for application $appInstanceNum in workload $workloadNum is $edgeService");
+			"EdgeService for application $appInstanceNum in workload $outputWorkloadNum is $edgeService");
 		$appInstanceParamHashRef->{'edgeService'} = $edgeService;
 
 		# Create and add the dataManager

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -659,7 +659,7 @@ $console_logger->info("Run Configuration has $numWorkloads workload(s).");
 my $workloadNum = 1;
 my @workloads;
 foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
-	my $outputWorkloadNum = ($numWorkloads == 1 ? undef : $workloadNum);
+	my $outputWorkloadNum = ($numWorkloads == 1 ? "" : $workloadNum);
 	
 	my $configSize = $workloadParamHashRef->{'configurationSize'};
 	# Check that the configurationSize is one of those allowed for this workload

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -700,7 +700,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 
 	my $workload = WorkloadFactory->getWorkload($workloadParamHashRef);
 
-	$workload->setWorkloadCount(100); # DELETE
+	$workload->{workloadCount} = $numWorkloads; # DELETE
 	my $TEST = $workload->workloadCount; # DELETE
 	print "TESTing $TEST\n"; # DELETE
 
@@ -773,7 +773,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 	my $host = getComputeResourceForInstance( $primaryDriverParamHashRef, $driverNum, "driver", 
 					\%nameToComputeResourceHash, $driverCluster, 
 					$paramsHashRef, $runProcedureParamHashRef, $runProcedure);
-	my $workloadDriver = WorkloadDriverFactory->getWorkloadDriver($primaryDriverParamHashRef, $host);
+	my $workloadDriver = WorkloadDriverFactory->getWorkloadDriver($primaryDriverParamHashRef, $host, $numWorkloads);
 	$workloadDriver->host($host);
 	$workloadDriver->setWorkload($workload);
 	$workloadDriver->instanceNum($driverNum);
@@ -801,7 +801,7 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 		$host = getComputeResourceForInstance( $secondaryDriverParamHashRef, $driverNum, 
 												"driver", \%nameToComputeResourceHash, $driverCluster,
 												$paramsHashRef, $runProcedureParamHashRef, $runProcedure);
-		my $secondary = WorkloadDriverFactory->getWorkloadDriver($secondaryDriverParamHashRef, $host);
+		my $secondary = WorkloadDriverFactory->getWorkloadDriver($secondaryDriverParamHashRef, $host, $numWorkloads);
 		$secondary->host($host);
 		$secondary->instanceNum($driverNum);
 		$secondary->setWorkload($workload);

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -659,7 +659,6 @@ $console_logger->info("Run Configuration has $numWorkloads workload(s).");
 my $workloadNum = 1;
 my @workloads;
 foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
-	$workloadParamHashRef->{workloadCount} = $numWorkloads;
 	my $outputWorkloadNum = ($numWorkloads == 1 ? undef : $workloadNum);
 	
 	my $configSize = $workloadParamHashRef->{'configurationSize'};
@@ -700,6 +699,11 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 	}
 
 	my $workload = WorkloadFactory->getWorkload($workloadParamHashRef);
+
+	$workload->setWorkloadCount(100); # DELETE
+	my $TEST = $workload->workloadCount; # DELETE
+	print "TESTing $TEST\n"; # DELETE
+
 	$workload->instanceNum($workloadNum);
 	$workload->initialize();
 	push @workloads, $workload;

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -699,11 +699,6 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 	}
 
 	my $workload = WorkloadFactory->getWorkload($workloadParamHashRef);
-
-	$workload->{workloadCount} = $numWorkloads; # DELETE
-	my $TEST = $workload->workloadCount; # DELETE
-	print "TESTing $TEST\n"; # DELETE
-
 	$workload->instanceNum($workloadNum);
 	$workload->initialize();
 	push @workloads, $workload;

--- a/weathervane.pl
+++ b/weathervane.pl
@@ -843,12 +843,14 @@ foreach my $workloadParamHashRef (@$workloadsParamHashRefs) {
 		$console_logger->info("Workload $outputWorkloadNum has $numAppInstances application instances.");
 	}
 
+	my $tempOutWorkloadNum = ($numWorkloads == 1 ? "" : "Workload $workloadNum,");
+
 	# Create the appInstances and add them to the workload
 	my @appInstances;
 	my $appInstanceNum = 1;    # Count appInstances so that each gets a unique suffix
 	foreach my $appInstanceParamHashRef (@$appInstanceParamHashRefs) {
 		if (!$allAiSameConfig || ($commonConfigSize eq "custom")) {
-			$console_logger->info("Workload $outputWorkloadNum, Application Instance $appInstanceNum configuration:");
+			$console_logger->info("$tempOutWorkloadNum Application Instance $appInstanceNum configuration:");
 		}
 		
 		my $users = shift @usersList;


### PR DESCRIPTION
Added a new attribute to WorkloadDriver.pm called workloadCount that keeps track of how many workloads the run has. That attribute was then used to change the output to use either a workload number if there is more than one workload or an empty string if there's only one workload.

I will upload a full run's console output later today.