### PR TITLE
increasing micro app warmer cpus

### DIFF
--- a/runHarness/fixedConfigs.json
+++ b/runHarness/fixedConfigs.json
@@ -28,7 +28,7 @@
   "appServerJdbcConnections" : 26,
   "numAuctioneerThreads" : 1,  
   "appServerImpl" : "tomcat",
-  "appWarmerCpus" : "150m",
+  "appWarmerCpus" : "100m",
   "appWarmerMem" : "500Mi",
   "appServerWarmerThreadsPerServer" : 1,
   "appServerWarmerIterations" : 500,

--- a/runHarness/fixedConfigs.json
+++ b/runHarness/fixedConfigs.json
@@ -28,7 +28,7 @@
   "appServerJdbcConnections" : 26,
   "numAuctioneerThreads" : 1,  
   "appServerImpl" : "tomcat",
-  "appWarmerCpus" : "50m",
+  "appWarmerCpus" : "150m",
   "appWarmerMem" : "500Mi",
   "appServerWarmerThreadsPerServer" : 1,
   "appServerWarmerIterations" : 500,


### PR DESCRIPTION
Tested both 150m and 100m two times. Here's how long it took to start the backend services for each one:

**150**
* 17 minutes
* 14 minutes

**100**
* 15 minutes
* 14 minutes

Because both 100m and 150m produced similar results, I changed the appWarmerCpus parameter to 100m.