### PR TITLE
Add different namespaces for each configuration size

### DIFF
--- a/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.micro
+++ b/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.micro
@@ -27,6 +27,13 @@
   "appInstanceCluster" : "appCluster",
   "appIngressMethod" : "nodeport",
 
+  # Each configuration size is in its own namespace.
+  # This ensures the db will not have to be reloaded when running different
+  # configuration sizes, significantly decreasing the time required for end 
+  # to end testing.
+  "namespaceSuffix" : "-micro",
+  "createNamespaces" : true,
+
   "cassandraDataStorageClass" : "fast",
   "postgresqlStorageClass" : "fast",
   "nginxCacheStorageClass" : "fast",

--- a/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.small2
+++ b/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.small2
@@ -27,6 +27,13 @@
   "appInstanceCluster" : "appCluster",
   "appIngressMethod" : "nodeport",
 
+  # Each configuration size is in its own namespace.
+  # This ensures the db will not have to be reloaded when running different
+  # configuration sizes, significantly decreasing the time required for end 
+  # to end testing.
+  "namespaceSuffix" : "-small2",
+  "createNamespaces" : true,
+
   "cassandraDataStorageClass" : "fast",
   "postgresqlStorageClass" : "fast",
   "nginxCacheStorageClass" : "fast",

--- a/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.small3
+++ b/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.small3
@@ -27,6 +27,13 @@
   "appInstanceCluster" : "appCluster",
   "appIngressMethod" : "nodeport",
 
+  # Each configuration size is in its own namespace.
+  # This ensures the db will not have to be reloaded when running different
+  # configuration sizes, significantly decreasing the time required for end 
+  # to end testing.
+  "namespaceSuffix" : "-small3",
+  "createNamespaces" : true,
+
   "cassandraDataStorageClass" : "fast",
   "postgresqlStorageClass" : "fast",
   "nginxCacheStorageClass" : "fast",

--- a/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.xsmall
+++ b/testing/e2e/weathervaneConfigFiles/weathervane.config.k8s.xsmall
@@ -27,6 +27,13 @@
   "appInstanceCluster" : "appCluster",
   "appIngressMethod" : "nodeport",
 
+  # Each configuration size is in its own namespace.
+  # This ensures the db will not have to be reloaded when running different
+  # configuration sizes, significantly decreasing the time required for end 
+  # to end testing.
+  "namespaceSuffix" : "-xsmall",
+  "createNamespaces" : true,
+
   "cassandraDataStorageClass" : "fast",
   "postgresqlStorageClass" : "fast",
   "nginxCacheStorageClass" : "fast",


### PR DESCRIPTION
Modified weathervane config files to create a different namespace for each configuration size. 
With this change, unique PVCs are created for each namespace. The DB PVC remains loaded and does not require a reload on configuration size change. This speeds up testing.

Testing:
https://weathervane.svc.eng.vmware.com/job/weathervane-featurebranch/50
Build 50 is not requiring database reloads. 
Build 50 did fail to schedule small2 and small3 due to a kubernetes worker node disk pressure, but I couldn't replicate the disk pressure this morning, and the pipeline was running small 2 and small3 correctly yesterday. 

Edit: Test run has completed successfully, https://weathervane.svc.eng.vmware.com/job/weathervane-featurebranch/51

Signed-off-by: Rebecca Yo <griderr@vmware.com>