### PR TITLE
WEAT-401: Specify OpenJDK for Cassandra image: 1.8.0.322.b06-1.el7_9

### DIFF
--- a/dockerImages/cassandra/Dockerfile
+++ b/dockerImages/cassandra/Dockerfile
@@ -15,8 +15,8 @@ COPY cassandra.yaml /cassandra.yaml
 COPY jvm.options /jvm.options
 ARG http_proxy
 
-RUN yum install -y java-1.8.0-openjdk && \
-	yum install -y java-1.8.0-openjdk-devel && \
+RUN yum install -y http://mirror.centos.org/centos/7/updates/x86_64/Packages/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64.rpm && \
+	yum install -y http://mirror.centos.org/centos/7/updates/x86_64/Packages/java-1.8.0-openjdk-devel-1.8.0.322.b06-1.el7_9.x86_64.rpm && \
 	yum install -y python && \
 	yum install -y https://archive.apache.org/dist/cassandra/redhat/311x/cassandra-3.11.10-1.noarch.rpm && \
 	yum -y clean all && \


### PR DESCRIPTION
An update to OpenJDK package results in Cassandra no longer able to deploy:
`Warning Unhealthy 24s (x10 over 9m24s) kubelet Readiness probe failed: nodetool: Failed to connect to '127.0.0.1:7199' - URISyntaxException: 'Malformed IPv6 address at index 7: rmi://[127.0.0.1]:7199'.`

This is an incompatibility between Cassandra and the new OpenJDK version: https://stackoverflow.com/questions/72258217/cassandra-nodetool-urisyntaxexception-malformed-ipv6-address-at-index-7 

Cassandra appears to have been fixed to be compatible with the latest OpenJDK version but we don't expect it will be released until 3.11.15 which we should test at at that time.

We decided to specify the last working version of openjdk for Cassandra until we can update Cassandra to 3.11.15 or use the workaround described at stackoverflow above.

Details on the packages specified in the Dockerfile are:
https://centos.pkgs.org/7/centos-updates-x86_64/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64.rpm.html
https://centos.pkgs.org/7/centos-updates-x86_64/java-1.8.0-openjdk-devel-1.8.0.322.b06-1.el7_9.x86_64.rpm.html

I tested this change privately and a CICD test can be found at https://weathervane.svc.eng.vmware.com/job/weathervane-featurebranch/52/
Signed-off-by: Rebecca Yo <griderr@vmware.com>