### PR TITLE
Added a Check for the rampDown

### DIFF
--- a/weathervane.pl
+++ b/weathervane.pl
@@ -558,6 +558,11 @@ if (getParamValue( $paramsHashRef, "findMaxStopPct" ) <= 0) {
 	die "The value for findMaxStopPct must be greater than 0.\n";
 }
 
+# rampDown>0 check to prevent the run hanging   
+if (getParamValue( $paramsHashRef, "rampDown" ) <= 0) {
+        die "The value for rampDown must be greater than 0.\n";
+}
+
 # hash to build up the as-run parameter output
 my $paramsAsRun = \%$paramsHashRef;
 


### PR DESCRIPTION
- When rampDown is set to 0, it does keep the current run of weathervane in hanging state.
- To prevent this, added a check for rampDown time. We are stopping the current run id rampDown<=0

Signed-off-by: Ninad Ingale <ininad@ininad-a01.vmware.com>