### PR TITLE
Update the location of Cassandra repo

### DIFF
--- a/dockerImages/cassandra/cassandra.repo
+++ b/dockerImages/cassandra/cassandra.repo
@@ -4,4 +4,3 @@ baseurl=https://redhat.cassandra.apache.org/311x/
 gpgcheck=1 
 repo_gpgcheck=1 
 gpgkey=https://downloads.apache.org/cassandra/KEYS
-enabled=1

--- a/dockerImages/cassandra/cassandra.repo
+++ b/dockerImages/cassandra/cassandra.repo
@@ -1,7 +1,6 @@
 [cassandra] 
 name=Apache Cassandra 
-baseurl=https://www.apache.org/dist/cassandra/redhat/311x/ 
+baseurl=https://redhat.cassandra.apache.org/311x/
 gpgcheck=1 
 repo_gpgcheck=1 
-gpgkey=https://www.apache.org/dist/cassandra/KEYS
-enabled=1
+gpgkey=https://downloads.apache.org/cassandra/KEYS

--- a/dockerImages/cassandra/cassandra.repo
+++ b/dockerImages/cassandra/cassandra.repo
@@ -4,3 +4,4 @@ baseurl=https://redhat.cassandra.apache.org/311x/
 gpgcheck=1 
 repo_gpgcheck=1 
 gpgkey=https://downloads.apache.org/cassandra/KEYS
+enabled=1


### PR DESCRIPTION
This PR is for fixing the location of Cassandra repo which got moved to : https://cassandra.apache.org/_/download.html